### PR TITLE
Texlab settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ https://clang.llvm.org/extra/clangd/Installation.html
 clangd relies on a [JSON compilation database](https://clang.llvm.org/docs/JSONCompilationDatabase.html) specified
 as compile_commands.json or, for simpler projects, a compile_flags.txt.
 
-```json
+```lua
 nvim_lsp.clangd.setup({config})
 nvim_lsp#setup("clangd", {config})
 
@@ -191,7 +191,7 @@ If you don't want to use neovim to install it, then you can use:
 npm install -g elm elm-test elm-format @elm-tooling/elm-language-server
 ```
 
-```json
+```lua
 nvim_lsp.elmls.setup({config})
 nvim_lsp#setup("elmls", {config})
 
@@ -220,7 +220,7 @@ https://github.com/golang/tools/tree/master/gopls
 
 Google's lsp server for golang.
 
-```json
+```lua
 nvim_lsp.gopls.setup({config})
 nvim_lsp#setup("gopls", {config})
 
@@ -273,7 +273,7 @@ settings = {
 };
 ```
     
-```json
+```lua
 nvim_lsp.pyls.setup({config})
 nvim_lsp#setup("pyls", {config})
 
@@ -288,9 +288,11 @@ nvim_lsp#setup("pyls", {config})
 
 https://texlab.netlify.com/
 
-A completion engine built from scratch for (la)tex.
+A completion engine built from scratch for (La)TeX.
 
-```json
+See https://texlab.netlify.com/docs/reference/configuration for configuration options.
+
+```lua
 nvim_lsp.texlab.setup({config})
 nvim_lsp#setup("texlab", {config})
 
@@ -303,11 +305,23 @@ nvim_lsp#setup("texlab", {config})
     log_level = 2
     root_dir = vim's starting directory
     settings = {
+      bibtex = {
+        formatting = {
+          lineLength = 120
+        }
+      },
       latex = {
         build = {
           args = { "-pdf", "-interaction=nonstopmode", "-synctex=1" },
           executable = "latexmk",
           onSave = false
+        },
+        forwardSearch = {
+          args = {},
+          onSave = false
+        },
+        lint = {
+          onChange = false
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ https://clang.llvm.org/extra/clangd/Installation.html
 clangd relies on a [JSON compilation database](https://clang.llvm.org/docs/JSONCompilationDatabase.html) specified
 as compile_commands.json or, for simpler projects, a compile_flags.txt.
 
-```vim
+```json
 nvim_lsp.clangd.setup({config})
 nvim_lsp#setup("clangd", {config})
 
@@ -191,7 +191,7 @@ If you don't want to use neovim to install it, then you can use:
 npm install -g elm elm-test elm-format @elm-tooling/elm-language-server
 ```
 
-```vim
+```json
 nvim_lsp.elmls.setup({config})
 nvim_lsp#setup("elmls", {config})
 
@@ -220,7 +220,7 @@ https://github.com/golang/tools/tree/master/gopls
 
 Google's lsp server for golang.
 
-```vim
+```json
 nvim_lsp.gopls.setup({config})
 nvim_lsp#setup("gopls", {config})
 
@@ -273,7 +273,7 @@ settings = {
 };
 ```
     
-```vim
+```json
 nvim_lsp.pyls.setup({config})
 nvim_lsp#setup("pyls", {config})
 
@@ -290,7 +290,7 @@ https://texlab.netlify.com/
 
 A completion engine built from scratch for (la)tex.
 
-```vim
+```json
 nvim_lsp.texlab.setup({config})
 nvim_lsp#setup("texlab", {config})
 

--- a/lua/nvim_lsp/texlab.lua
+++ b/lua/nvim_lsp/texlab.lua
@@ -46,6 +46,19 @@ skeleton.texlab = {
           executable = "latexmk";
           onSave = false;
         };
+        forwardSearch = {
+          args = {};
+          executable = nil;
+          onSave = false;
+        };
+        lint = { 
+          onChange = false; 
+        };
+      };
+      bibtex = { 
+        formatting = { 
+          lineLength = 120 
+        }; 
       };
     };
   };
@@ -65,7 +78,9 @@ skeleton.texlab = {
     description = [[
 https://texlab.netlify.com/
 
-A completion engine built from scratch for (la)tex.
+A completion engine built from scratch for (La)TeX.
+
+See https://texlab.netlify.com/docs/reference/configuration for configuration options.
 ]];
     default_config = {
       root_dir = "vim's starting directory";

--- a/scripts/docgen.lua
+++ b/scripts/docgen.lua
@@ -97,7 +97,7 @@ for _, k in ipairs(skeleton_keys) do
 ## {{template_name}}
 
 {{preamble}}
-```vim
+```lua
 nvim_lsp.{{template_name}}.setup({config})
 nvim_lsp#setup("{{template_name}}", {config})
 


### PR DESCRIPTION
Adds the complete set of texlab settings.

Also makes a small change to the docgen script to declare fenced code as lua (vim colors the `s:` in `Commands:`).