### PR TITLE
Improve docgen

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         curl -OL https://raw.githubusercontent.com/norcalli/bot-ci/master/scripts/github-actions-setup.sh
         source github-actions-setup.sh nightly-x64
-        nvim -u NONE +'set rtp+=$PWD' +"luafile scripts/docgen.lua" +q
+        scripts/docgen.sh
     - name: Commit changes
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ them are good references.
 
 ## Progress
 
-Implemented:
+Implemented language servers:
 - [bashls](https://github.com/neovim/nvim-lsp#bashls)
 - [clangd](https://github.com/neovim/nvim-lsp#clangd)
 - [elmls](https://github.com/neovim/nvim-lsp#elmls)
-- [gopls](https://github.com/neovim/nvim-lsp#gopls) (has some errors)
+- [gopls](https://github.com/neovim/nvim-lsp#gopls)
 - [pyls](https://github.com/neovim/nvim-lsp#pyls)
 - [texlab](https://github.com/neovim/nvim-lsp#texlab)
 - [tsserver](https://github.com/neovim/nvim-lsp#tsserver)
@@ -175,10 +175,12 @@ nvim_lsp.SERVER.setup({config})
 ```
 
 # LSP Implementations
+
 ## bashls
 
-For install instruction visit:
-https://github.com/mads-hartmann/bash-language-server#installation
+https://github.com/mads-hartmann/bash-language-server
+
+Language server for bash, written using tree sitter in typescript.
 
 Can be installed in neovim with `:LspInstall bashls`
 
@@ -193,6 +195,7 @@ nvim_lsp#setup("bashls", {config})
     root_dir = vim's starting directory
     settings = {}
 ```
+
 ## clangd
 
 https://clang.llvm.org/extra/clangd/Installation.html
@@ -214,6 +217,7 @@ nvim_lsp#setup("clangd", {config})
     root_dir = root_pattern("compile_commands.json", "compile_flags.txt", ".git")
     settings = {}
 ```
+
 ## elmls
 
 https://github.com/elm-tooling/elm-language-server#installation
@@ -244,6 +248,7 @@ nvim_lsp#setup("elmls", {config})
     root_dir = root_pattern("elm.json")
     settings = {}
 ```
+
 ## gopls
 
 https://github.com/golang/tools/tree/master/gopls
@@ -262,6 +267,7 @@ nvim_lsp#setup("gopls", {config})
     root_dir = root_pattern("go.mod", ".git")
     settings = {}
 ```
+
 ## pyls
 
 https://github.com/palantir/python-language-server
@@ -316,6 +322,7 @@ nvim_lsp#setup("pyls", {config})
     root_dir = vim's starting directory
     settings = {}
 ```
+
 ## texlab
 
 https://texlab.netlify.com/
@@ -359,6 +366,7 @@ nvim_lsp#setup("texlab", {config})
       }
     }
 ```
+
 ## tsserver
 
 https://github.com/theia-ide/typescript-language-server

--- a/README_preamble.md
+++ b/README_preamble.md
@@ -30,14 +30,7 @@ them are good references.
 
 ## Progress
 
-Implemented:
-- [bashls](https://github.com/neovim/nvim-lsp#bashls)
-- [clangd](https://github.com/neovim/nvim-lsp#clangd)
-- [elmls](https://github.com/neovim/nvim-lsp#elmls)
-- [gopls](https://github.com/neovim/nvim-lsp#gopls) (has some errors)
-- [pyls](https://github.com/neovim/nvim-lsp#pyls)
-- [texlab](https://github.com/neovim/nvim-lsp#texlab)
-- [tsserver](https://github.com/neovim/nvim-lsp#tsserver)
+Implemented language servers:
 
 Planned servers to implement (by me, but contributions welcome anyway):
 - [ccls](https://github.com/MaskRay/ccls)

--- a/lua/nvim_lsp/bashls.lua
+++ b/lua/nvim_lsp/bashls.lua
@@ -35,8 +35,9 @@ skeleton[server_name] = {
   -- on_attach = function(client, bufnr) end;
   docs = {
     description = [[
-For install instruction visit:
-https://github.com/mads-hartmann/bash-language-server#installation
+https://github.com/mads-hartmann/bash-language-server
+
+Language server for bash, written using tree sitter in typescript.
 ]];
     default_config = {
       root_dir = "vim's starting directory";

--- a/scripts/docgen.sh
+++ b/scripts/docgen.sh
@@ -1,4 +1,2 @@
 #!/bin/sh
-# exec nvim-master -u NONE +'set rtp+=$PWD' +'luafile scripts/docgen.lua'
 exec nvim-master -u NONE -E -R --headless +'set rtp+=$PWD' +'luafile scripts/docgen.lua' +q
-#exec nvim-master -u NONE -Es +'set rtp+=$PWD' +'luafile scripts/docgen.lua' +q

--- a/scripts/docgen.sh
+++ b/scripts/docgen.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# exec nvim-master -u NONE +'set rtp+=$PWD' +'luafile scripts/docgen.lua'
+exec nvim-master -u NONE -E -R --headless +'set rtp+=$PWD' +'luafile scripts/docgen.lua' +q
+#exec nvim-master -u NONE -Es +'set rtp+=$PWD' +'luafile scripts/docgen.lua' +q

--- a/scripts/docgen.sh
+++ b/scripts/docgen.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec nvim-master -u NONE -E -R --headless +'set rtp+=$PWD' +'luafile scripts/docgen.lua' +q
+exec nvim -u NONE -E -R --headless +'set rtp+=$PWD' +'luafile scripts/docgen.lua' +q


### PR DESCRIPTION
Improve docgen.

- Automatically generate the `Implemented servers` section.
- Remove dependency on `cat`
- Provide scripts/docgen.sh which actually reports errors.