### PR TITLE
Add intelephense (PHP)

### DIFF
--- a/lua/nvim_lsp.lua
+++ b/lua/nvim_lsp.lua
@@ -20,6 +20,7 @@ require 'nvim_lsp/solargraph'
 require 'nvim_lsp/sumneko_lua'
 require 'nvim_lsp/texlab'
 require 'nvim_lsp/tsserver'
+require 'nvim_lsp/intelephense'
 
 local M = {
   util = require 'nvim_lsp/util';

--- a/lua/nvim_lsp.lua
+++ b/lua/nvim_lsp.lua
@@ -11,6 +11,7 @@ require 'nvim_lsp/fortls'
 require 'nvim_lsp/ghcide'
 require 'nvim_lsp/gopls'
 require 'nvim_lsp/hie'
+require 'nvim_lsp/intelephense'
 require 'nvim_lsp/leanls'
 require 'nvim_lsp/pyls'
 require 'nvim_lsp/pyls_ms'
@@ -20,7 +21,6 @@ require 'nvim_lsp/solargraph'
 require 'nvim_lsp/sumneko_lua'
 require 'nvim_lsp/texlab'
 require 'nvim_lsp/tsserver'
-require 'nvim_lsp/intelephense'
 
 local M = {
   util = require 'nvim_lsp/util';

--- a/lua/nvim_lsp/intelephense.lua
+++ b/lua/nvim_lsp/intelephense.lua
@@ -17,7 +17,16 @@ skeleton[server_name] = {
     filetypes = {"php"};
     root_dir = util.root_pattern("composer.json");
     log_level = lsp.protocol.MessageType.Warning;
-    settings = {};
+    settings = {
+      intelephense = {
+        environment = {
+          documentRoot = ""
+        }
+      }
+    };
+    init_options = {
+      licenceKey = ""
+    }
   };
   on_new_config = function(new_config)
     local install_info = installer.info()

--- a/lua/nvim_lsp/intelephense.lua
+++ b/lua/nvim_lsp/intelephense.lua
@@ -23,16 +23,6 @@ skeleton[server_name] = {
       return util.path.is_descendant(cwd, root) and cwd or root;
     end;
     log_level = lsp.protocol.MessageType.Warning;
-    settings = {
-      intelephense = {
-        environment = {
-          documentRoot = "";
-        };
-      };
-    };
-    init_options = {
-      licenceKey = "";
-    };
   };
   on_new_config = function(new_config)
     local install_info = installer.info()
@@ -59,7 +49,19 @@ npm install -g intelephense
       on_init = [[function to handle changing offsetEncoding]];
       capabilities = [[default capabilities, with offsetEncoding utf-8]];
       init_options = [[{
-        licenceKey = ""
+        storagePath = Optional absolute path to storage dir. Defaults to os.tmpdir().
+        globalStoragePath = Optional absolute path to a global storage dir. Defaults to os.homedir().
+        licenceKey = Optional licence key or absolute path to a text file containing the licence key.
+        clearCache = Optional flag to clear server state. State can also be cleared by deleting {storagePath}/intelephense
+        -- See https://github.com/bmewburn/intelephense-docs#initialisation-options
+      }]];
+      settings = [[{
+        intelephense = {
+          files = {
+            maxSize = 1000000;
+          };
+        };
+        -- See https://github.com/bmewburn/intelephense-docs#configuration-options
       }]];
     };
   };
@@ -68,4 +70,3 @@ npm install -g intelephense
 skeleton[server_name].install = installer.install
 skeleton[server_name].install_info = installer.info
 -- vim:et ts=2 sw=2
-

--- a/lua/nvim_lsp/intelephense.lua
+++ b/lua/nvim_lsp/intelephense.lua
@@ -1,0 +1,53 @@
+local skeleton = require 'nvim_lsp/skeleton'
+local util = require 'nvim_lsp/util'
+local lsp = vim.lsp
+
+local server_name = "intelephense"
+local bin_name = "intelephense"
+
+local installer = util.npm_installer {
+  server_name = server_name;
+  packages = { "intelephense" };
+  binaries = {bin_name};
+}
+
+skeleton[server_name] = {
+  default_config = util.utf8_config {
+    cmd = {bin_name, "--stdio"};
+    filetypes = {"php"};
+    root_dir = util.root_pattern("package.json");
+    log_level = lsp.protocol.MessageType.Warning;
+    settings = {};
+  };
+  on_new_config = function(new_config)
+    local install_info = installer.info()
+    if install_info.is_installed then
+      if type(new_config.cmd) == 'table' then
+        -- Try to preserve any additional args from upstream changes.
+        new_config.cmd[1] = install_info.binaries[bin_name]
+      else
+        new_config.cmd = {install_info.binaries[bin_name]}
+      end
+    end
+  end;
+  docs = {
+    description = [[
+https://intelephense.com/
+
+`intelephense` can be installed via `:LspInstall intelephense` or by yourself with `npm`: 
+```sh
+npm install -g intelephense
+```
+]];
+    default_config = {
+      root_dir = [[root_pattern("package.json")]];
+      on_init = [[function to handle changing offsetEncoding]];
+      capabilities = [[default capabilities, with offsetEncoding utf-8]];
+    };
+  };
+}
+
+skeleton[server_name].install = installer.install
+skeleton[server_name].install_info = installer.info
+-- vim:et ts=2 sw=2
+

--- a/lua/nvim_lsp/intelephense.lua
+++ b/lua/nvim_lsp/intelephense.lua
@@ -65,9 +65,12 @@ npm install -g intelephense
 ```
 ]];
     default_config = {
-      root_dir = [[root_pattern("composer.json")]];
+      root_dir = [[root_pattern("composer.json", ".git")]];
       on_init = [[function to handle changing offsetEncoding]];
       capabilities = [[default capabilities, with offsetEncoding utf-8]];
+      init_options = [[{
+        licenceKey = ""
+      }]];
     };
   };
 }

--- a/lua/nvim_lsp/intelephense.lua
+++ b/lua/nvim_lsp/intelephense.lua
@@ -11,16 +11,6 @@ local installer = util.npm_installer {
   binaries = {bin_name};
 }
 
-local function is_inside_cwd(path, cwd)
-  local function cb(dir, _)
-    return dir == cwd;
-  end
-
-  local dir, _ = util.path.traverse_parents(path, cb);
-
-  return dir == cwd;
-end
-
 skeleton[server_name] = {
   default_config = util.utf8_config {
     cmd = {bin_name, "--stdio"};
@@ -30,7 +20,7 @@ skeleton[server_name] = {
       local root = util.root_pattern("composer.json", ".git")(pattern);
 
       -- prefer cwd if it is inside root
-      return is_inside_cwd(root, cwd) and cwd or root;
+      return util.path.is_descendant(cwd, root) and cwd or root;
     end;
     log_level = lsp.protocol.MessageType.Warning;
     settings = {

--- a/lua/nvim_lsp/intelephense.lua
+++ b/lua/nvim_lsp/intelephense.lua
@@ -15,7 +15,7 @@ skeleton[server_name] = {
   default_config = util.utf8_config {
     cmd = {bin_name, "--stdio"};
     filetypes = {"php"};
-    root_dir = util.root_pattern("package.json");
+    root_dir = util.root_pattern("composer.json");
     log_level = lsp.protocol.MessageType.Warning;
     settings = {};
   };
@@ -40,7 +40,7 @@ npm install -g intelephense
 ```
 ]];
     default_config = {
-      root_dir = [[root_pattern("package.json")]];
+      root_dir = [[root_pattern("composer.json")]];
       on_init = [[function to handle changing offsetEncoding]];
       capabilities = [[default capabilities, with offsetEncoding utf-8]];
     };

--- a/lua/nvim_lsp/intelephense.lua
+++ b/lua/nvim_lsp/intelephense.lua
@@ -19,7 +19,7 @@ skeleton[server_name] = {
       local cwd  = vim.loop.cwd();
       local root = util.root_pattern("composer.json", ".git")(pattern);
 
-      -- prefer cwd if it is inside root
+      -- prefer cwd if root is a descendant
       return util.path.is_descendant(cwd, root) and cwd or root;
     end;
     log_level = lsp.protocol.MessageType.Warning;

--- a/lua/nvim_lsp/util.lua
+++ b/lua/nvim_lsp/util.lua
@@ -182,6 +182,16 @@ M.path = (function()
     return it, path, path
   end
 
+  local function is_descendant(root, path)
+    local function cb(dir, _)
+      return dir == root;
+    end
+
+    local dir, _ = traverse_parents(path, cb);
+
+    return dir == root;
+  end
+
   return {
     is_dir = is_dir;
     is_file = is_file;
@@ -191,6 +201,7 @@ M.path = (function()
     join = path_join;
     traverse_parents = traverse_parents;
     iterate_parents = iterate_parents;
+    is_descendant = is_descendant;
   }
 end)()
 

--- a/lua/nvim_lsp/util.lua
+++ b/lua/nvim_lsp/util.lua
@@ -183,6 +183,10 @@ M.path = (function()
   end
 
   local function is_descendant(root, path)
+    if (not path) then
+      return false;
+    end
+
     local function cb(dir, _)
       return dir == root;
     end


### PR DESCRIPTION
This is just a modified `tsserver` script since `intelephense` is in NPM and is started the same way. 

It works, however at least in my setup I get the following error when opening a PHP file:

```
Error executing vim.schedule lua callback: ...r/neovim/HEAD-b1e4ec1/share/nvim/runtime/lua/vim/lsp.lua:430: RPC InternalError message =  "Request initialize failed with message: Cannot read property 'dataPaths' of undefined"
```

Not sure if this is an issue with neovim or Intelephense. 

Also, Intelephense has a premium mode which can be enabled using the `licenseKey` initialization option. See here: https://github.com/bmewburn/intelephense-docs

Any ideas how that would be configured? 