### PR TITLE
revise docs; remove Vimscript wrapper

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,34 +1,28 @@
 # Requirements
 
 - Neovim :P
-- The docgen requires \*nix systems for now.
+- docgen requires a unix system.
 
 # Generating docs
 
 > NOTE: Github Actions automatically generates the docs, so only modify
-> README_preamble.md or the `docs` in the server config!
+> `README_template.md` or the `docs` object on the server config!
+> **DO NOT MODIFY `README.md` DIRECTLY**
 
-The instructions here are for previewing changes locally.
+To preview the generated `README.md` locally, source `scripts/docgen.lua` from
+`nvim` (e.g. with `:luafile`):
 
-`scripts/docgen.lua` was written with the intention of being sourced (like with `luafile`)
-from `nvim` to run.
+    nvim -R -Es +'set rtp+=$PWD' +'luafile scripts/docgen.lua'
 
-It **must** be run from the .git/project root. This could be modified to try to
-find the .git root with one of our `util.*` functions potentially.
-
-You can run `scripts/docgen.sh` from the project root. This ensures that it
-doesn't pick up another copy of `nvim_lsp` on your system.
-
-This generates README.md
-
-**DO NOT MODIFY `README.md` DIRECTLY**
+It **must** be run from the `.git`/project root. (TODO: try to find the `.git`
+root with one of our `util.*` functions?)
 
 # skeleton
 
 skeleton has a `__newindex` metamethod which validates and creates
 an object containing `setup()`, which can then be retrieved and modified.
 
-In vim.validate parlance, this is the format to use.
+In `vim.validate` parlance, this is the "spec":
 
 ```
 skeleton.SERVER_NAME = {
@@ -44,16 +38,14 @@ docs = {
 }
 ```
 
-The docs `default_config` is a table whose keys match the other `default_config`,
-and can be used to specify a string in place of using `vim.inspect(value)` to
-generate the documentation. This is useful for functions, whose output would
-be unhelpful otherwise.
-
-`commands` is a table of key/value pairs from `command_name -> {definition}`.
-The format of `{definition}` is a table where the first array value
-is a function which will be called for this command. The other table values
-are either array values which will be formed into flags for the command or
-special keys like `description`.
+- Keys of the `docs.default_config` table match those of
+  `skeleton.SERVER_NAME.default_config`, and can be used to specify custom
+  documentation. This is useful for functions, whose docs cannot be easily
+  auto-generated.
+- The `commands` object is a table of `name:definition` key:value pairs, where
+  `definition` is a list whose first value is a function implementing the
+  command. The other table values are either array values which will be formed
+  into flags for the command or special keys like `description`.
 
 Example:
 
@@ -70,24 +62,19 @@ Example:
 ```
 
 
-After you create a `skeleton.SERVER_NAME`, you can add functions to it that you
-wish to expose to the user.
+After you create `skeleton.SERVER_NAME`, you may add arbitrary
+language-specific functions to it if necessary.
 
 Example:
 
-```
-skeleton.texlab.buf_build = buf_build
-```
+    skeleton.texlab.buf_build = buf_build
 
-After you create a skeleton, you have to `require 'nvim_lsp/SERVER_NAME'` in
-`lua/nvim_lsp.lua`, and that's it.
+Finally, add a `require 'nvim_lsp/SERVER_NAME'` line to `lua/nvim_lsp.lua`.
 
-Generate docs and you're done.
+# Auto-installation
 
-# Supporting installation
-
-If a skeleton has the functions `.install()` and `.install_info()` available, then
-it will be picked up by `LspInstall` and `LspInstallInfo`.
+Configs may optionally provide `install()` and `install_info()` functions.
+This will be recognized by `:LspInstall` and `:LspInstallInfo`.
 
 `function install()` is the signature and it is expected that it will create
 any data in `util.base_install_dir/{server_name}`.
@@ -97,4 +84,4 @@ which indicates the current status of installation (if it is installed by us).
 It can contain any other additional data that the user may find useful.
 
 The helper function `util.npm_installer` can be used for lsps which are installed
-with `npm`. See `elmls.lua` or `tsserver.lua` or `bashls.lua` for example usage.
+with `npm`. See `elmls.lua`, `tsserver.lua`, or `bashls.lua` for examples.

--- a/README.md
+++ b/README.md
@@ -1,37 +1,59 @@
 # nvim-lsp
 
-WIP Common configurations for Language Servers.
+Collection of common configurations for the Neovim `vim.lsp` LSP client. These
+configurations hopefully work automatically, but are otherwise _best effort_.
+If you find a problem, send a pull request with the fix.
 
-This repository aims to be a central location to store configurations for
-Language Servers which leverage Neovim's built-in LSP client `vim.lsp` as the
-client backbone. The `vim.lsp` implementation is made to be customizable and
-greatly extensible, but most users just want to get up and going. This
-plugin/library is for those people, although it still lets you customize
-things as much as you want in addition to the defaults that this provides.
+`vim.lsp` is designed to be customizable and highly extensible, but most users
+just want to get up and going. This collection is intended to get you started
+quickly, in the ideal case. You can still customize things as much as you want
+in addition to the defaults provided here.
 
-**NOTE**: Requires current Neovim master as of 2019-11-13
+**Note**: This repository is a work-in-progress and requires Nvim HEAD. Update
+nvim-lsp and Nvim before reporting an issue.
 
-**CONTRIBUTIONS ARE WELCOME!**
+## Contributions are welcome!
 
-There's a lot of language servers in the world, and not enough time.  See
-[`lua/nvim_lsp/*.lua`](https://github.com/neovim/nvim-lsp/blob/master/lua/nvim_lsp/)
-for examples and ask us questions in the [Neovim
-Gitter](https://gitter.im/neovim/neovim) to help us complete configurations for
-*all the LSPs!* Read `CONTRIBUTING.md` for some instructions. NOTE: don't
-modify `README.md`; it is auto-generated.
+There are many language servers in the world, and not enough time.
+Help us create configs for *all the LSPs!*
 
-If you don't know where to start, you can pick one that's not in progress or
-implemented from [this excellent list compiled by the coc.nvim
-contributors](https://github.com/neoclide/coc.nvim/wiki/Language-servers) or
-[this other excellent list from the emacs lsp-mode
-contributors](https://github.com/emacs-lsp/lsp-mode#supported-languages)
-and create a new file under `lua/nvim_lsp/SERVER_NAME.lua`. We recommend
-looking at `lua/nvim_lsp/texlab.lua` for the most extensive example, but all of
-them are good references.
+- See [existing configs](https://github.com/neovim/nvim-lsp/blob/master/lua/nvim_lsp/)
+  for examples
+- Ask questions in [Neovim Gitter](https://gitter.im/neovim/neovim)
+- Read [CONTRIBUTING.md](CONTRIBUTING.md) for instructions.
+- Don't modify `README.md`, it is auto-generated.
 
-## Progress
+Quickstart:
 
-Implemented language servers:
+1. Choose a language from [the coc.nvim wiki](https://github.com/neoclide/coc.nvim/wiki/Language-servers) or
+  [the emacs-lsp project](https://github.com/emacs-lsp/lsp-mode#supported-languages)
+2. Create a new file at `lua/nvim_lsp/SERVER_NAME.lua`
+3. `lua/nvim_lsp/texlab.lua` for an extensive example, but any
+   [existing config](https://github.com/neovim/nvim-lsp/blob/master/lua/nvim_lsp/) is a good reference.
+
+## Install
+
+**nvim-lsp** is just a plugin, so it can be installed like any other N/Vim
+plugin:
+
+    Plug 'neovim/nvim-lsp'
+
+## Usage
+
+Servers configurations can be set up with a "setup function." These are
+functions to set up servers more easily with some server specific defaults and
+more server specific things like commands or different diagnostics.
+
+The "setup functions" are `call nvim_lsp#setup({name}, {config})` from vim and
+`nvim_lsp[name].setup(config)` from Lua.
+
+Each config may define additional server-specific functions on the
+`nvim_lsp.SERVER` object, e.g. `nvim_lsp.texlab.buf_build({bufnr})`.
+
+## Configurations
+
+The following configurations are implemented:
+
 - [bashls](#bashls)
 - [ccls](#ccls)
 - [clangd](#clangd)
@@ -53,44 +75,21 @@ Implemented language servers:
 - [texlab](#texlab)
 - [tsserver](#tsserver)
 
-## Install
+### Installing language servers
 
-`Plug 'neovim/nvim-lsp'`
+Some configs provide auto-installation of the required language server via
+`:LspInstall <name>`.  For example, to install the Elm language server:
 
-## Usage
+    :LspInstall elmls
 
-Servers configurations can be set up with a "setup function." These are
-functions to set up servers more easily with some server specific defaults and
-more server specific things like commands or different diagnostics.
-
-The "setup functions" are `call nvim_lsp#setup({name}, {config})` from vim and
-`nvim_lsp[name].setup(config)` from Lua.
-
-Servers may define extra functions on the `nvim_lsp.SERVER` table, e.g.
-`nvim_lsp.texlab.buf_build({bufnr})`.
-
-### Auto Installation
-
-Many servers can be automatically installed with the `:LspInstall`
-command. Detailed installation info can be found
-with the `:LspInstallInfo` command, which optionally accepts a specific server name.
-
-For example:
-```vim
-LspInstall elmls
-silent LspInstall elmls " useful if you want to autoinstall in init.vim
-LspInstallInfo
-LspInstallInfo elmls
-```
+Detailed info is given by `:LspInstallInfo`, which optionally accepts a server
+name. Example:
 
 ### Example
 
-From vim:
-```vim
-call nvim_lsp#setup("texlab", {})
-```
+nvim-lsp is a Lua plugin, and all code samples below are in Lua. **It's easy to
+call Lua from Vimscript**: see `:help :lua-heredoc`.
 
-From Lua:
 ```lua
 require 'nvim_lsp'.texlab.setup {
   name = "texlab_fancy";
@@ -196,7 +195,6 @@ Can be installed in neovim with `:LspInstall bashls`
 
 ```lua
 nvim_lsp.bashls.setup({config})
-nvim_lsp#setup("bashls", {config})
 
   Default Values:
     cmd = { "bash-language-server", "start" }
@@ -614,7 +612,6 @@ This server accepts configuration via the `settings` key.
 
 ```lua
 nvim_lsp.ccls.setup({config})
-nvim_lsp#setup("ccls", {config})
 
   Default Values:
     capabilities = default capabilities, with offsetEncoding utf-8
@@ -638,7 +635,6 @@ as compile_commands.json or, for simpler projects, a compile_flags.txt.
 
 ```lua
 nvim_lsp.clangd.setup({config})
-nvim_lsp#setup("clangd", {config})
 
   Default Values:
     capabilities = default capabilities, with offsetEncoding utf-8
@@ -663,7 +659,6 @@ Can be installed in neovim with `:LspInstall cssls`
 
 ```lua
 nvim_lsp.cssls.setup({config})
-nvim_lsp#setup("cssls", {config})
 
   Default Values:
     capabilities = default capabilities, with offsetEncoding utf-8
@@ -698,7 +693,6 @@ Can be installed in neovim with `:LspInstall dockerls`
 
 ```lua
 nvim_lsp.dockerls.setup({config})
-nvim_lsp#setup("dockerls", {config})
 
   Default Values:
     cmd = { "docker-language-server", "--stdio" }
@@ -755,7 +749,6 @@ This server accepts configuration via the `settings` key.
 
 ```lua
 nvim_lsp.elmls.setup({config})
-nvim_lsp#setup("elmls", {config})
 
   Default Values:
     capabilities = default capabilities, with offsetEncoding utf-8
@@ -790,7 +783,6 @@ npm run flow lsp -- --help
 
 ```lua
 nvim_lsp.flow.setup({config})
-nvim_lsp#setup("flow", {config})
 
   Default Values:
     cmd = { "npm", "run", "flow", "lsp" }
@@ -879,7 +871,6 @@ This server accepts configuration via the `settings` key.
 
 ```lua
 nvim_lsp.fortls.setup({config})
-nvim_lsp#setup("fortls", {config})
 
   Default Values:
     cmd = { "fortls" }
@@ -916,7 +907,6 @@ This server accepts configuration via the `settings` key.
 
 ```lua
 nvim_lsp.ghcide.setup({config})
-nvim_lsp#setup("ghcide", {config})
 
   Default Values:
     cmd = { "ghcide", "--lsp" }
@@ -935,7 +925,6 @@ Google's lsp server for golang.
 
 ```lua
 nvim_lsp.gopls.setup({config})
-nvim_lsp#setup("gopls", {config})
 
   Default Values:
     cmd = { "gopls" }
@@ -1059,7 +1048,6 @@ This server accepts configuration via the `settings` key.
 
 ```lua
 nvim_lsp.hie.setup({config})
-nvim_lsp#setup("hie", {config})
 
   Default Values:
     cmd = { "hie-wrapper" }
@@ -1204,7 +1192,6 @@ This server accepts configuration via the `settings` key.
 
 ```lua
 nvim_lsp.leanls.setup({config})
-nvim_lsp#setup("leanls", {config})
 
   Default Values:
     cmd = { "lean-language-server", "--stdio" }
@@ -1487,7 +1474,6 @@ This server accepts configuration via the `settings` key.
 
 ```lua
 nvim_lsp.pyls.setup({config})
-nvim_lsp#setup("pyls", {config})
 
   Default Values:
     cmd = { "pyls" }
@@ -1506,7 +1492,6 @@ Can be installed in neovim with `:LspInstall pyls_ms`
 
 ```lua
 nvim_lsp.pyls_ms.setup({config})
-nvim_lsp#setup("pyls_ms", {config})
 
   Default Values:
     filetypes = { "python" }
@@ -1757,7 +1742,6 @@ This server accepts configuration via the `settings` key.
 
 ```lua
 nvim_lsp.rls.setup({config})
-nvim_lsp#setup("rls", {config})
 
   Default Values:
     cmd = { "rls" }
@@ -1873,7 +1857,6 @@ This server accepts configuration via the `settings` key.
 
 ```lua
 nvim_lsp.rust_analyzer.setup({config})
-nvim_lsp#setup("rust_analyzer", {config})
 
   Default Values:
     capabilities = {
@@ -2038,7 +2021,6 @@ This server accepts configuration via the `settings` key.
 
 ```lua
 nvim_lsp.solargraph.setup({config})
-nvim_lsp#setup("solargraph", {config})
 
   Default Values:
     cmd = { "solargraph", "stdio" }
@@ -2133,7 +2115,6 @@ This server accepts configuration via the `settings` key.
 
 ```lua
 nvim_lsp.sumneko_lua.setup({config})
-nvim_lsp#setup("sumneko_lua", {config})
 
   Default Values:
     filetypes = { "lua" }
@@ -2153,7 +2134,6 @@ See https://texlab.netlify.com/docs/reference/configuration for configuration op
 
 ```lua
 nvim_lsp.texlab.setup({config})
-nvim_lsp#setup("texlab", {config})
 
   Commands:
   - TexlabBuild: Build the current buffer
@@ -2199,7 +2179,6 @@ Can be installed in neovim with `:LspInstall tsserver`
 
 ```lua
 nvim_lsp.tsserver.setup({config})
-nvim_lsp#setup("tsserver", {config})
 
   Default Values:
     capabilities = default capabilities, with offsetEncoding utf-8

--- a/README.md
+++ b/README.md
@@ -1,58 +1,198 @@
 # nvim-lsp
 
-Collection of common configurations for the Neovim `vim.lsp` LSP client. These
-configurations hopefully work automatically, but are otherwise _best effort_.
-If you find a problem, send a pull request with the fix.
+Collection of common configurations for the [Nvim LSP client](https://neovim.io/doc/user/lsp.html).
 
-`vim.lsp` is designed to be customizable and highly extensible, but most users
-just want to get up and going. This collection is intended to get you started
-quickly, in the ideal case. You can still customize things as much as you want
-in addition to the defaults provided here.
+It is hoped that these configurations serve as a "source of truth", but they
+are strictly _best effort_. If something doesn't work, these configs are useful
+as a starting point, which you can adjust to fit your environment.
 
-**Note**: This repository is a work-in-progress and requires Nvim HEAD. Update
-nvim-lsp and Nvim before reporting an issue.
+**Note**: This is a work-in-progress and requires Nvim HEAD. Update Nvim and
+nvim-lsp before reporting an issue.
 
 ## Contributions are welcome!
 
 There are many language servers in the world, and not enough time.
 Help us create configs for *all the LSPs!*
 
-- See [existing configs](https://github.com/neovim/nvim-lsp/blob/master/lua/nvim_lsp/)
-  for examples
-- Ask questions in [Neovim Gitter](https://gitter.im/neovim/neovim)
-- Read [CONTRIBUTING.md](CONTRIBUTING.md) for instructions.
-- Don't modify `README.md`, it is auto-generated.
-
-Quickstart:
-
+0. Read [CONTRIBUTING.md](CONTRIBUTING.md) for instructions.
+   Ask questions in [Neovim Gitter](https://gitter.im/neovim/neovim).
 1. Choose a language from [the coc.nvim wiki](https://github.com/neoclide/coc.nvim/wiki/Language-servers) or
-  [the emacs-lsp project](https://github.com/emacs-lsp/lsp-mode#supported-languages)
-2. Create a new file at `lua/nvim_lsp/SERVER_NAME.lua`
-3. `lua/nvim_lsp/texlab.lua` for an extensive example, but any
-   [existing config](https://github.com/neovim/nvim-lsp/blob/master/lua/nvim_lsp/) is a good reference.
+  [the emacs-lsp project](https://github.com/emacs-lsp/lsp-mode#supported-languages).
+2. Create a new file at `lua/nvim_lsp/SERVER_NAME.lua`. See
+   [existing configs](https://github.com/neovim/nvim-lsp/blob/master/lua/nvim_lsp/) for
+   examples (`lua/nvim_lsp/texlab.lua` is an extensive example).
 
 ## Install
 
-**nvim-lsp** is just a plugin, so it can be installed like any other N/Vim
-plugin:
+**nvim-lsp** is just a plugin. Install it like any other Nvim plugin:
 
     Plug 'neovim/nvim-lsp'
 
 ## Usage
 
-Servers configurations can be set up with a "setup function." These are
-functions to set up servers more easily with some server specific defaults and
-more server specific things like commands or different diagnostics.
+Each config provides a `setup()` function, to initialize the server with
+reasonable defaults and some server-specific things like commands or different
+diagnostics.
 
-The "setup functions" are `call nvim_lsp#setup({name}, {config})` from vim and
-`nvim_lsp[name].setup(config)` from Lua.
+    nvim_lsp[name].setup{name=…, settings = {…}, …}
 
-Each config may define additional server-specific functions on the
-`nvim_lsp.SERVER` object, e.g. `nvim_lsp.texlab.buf_build({bufnr})`.
+Find the [config](#configurations) for your language, then paste the example
+given there to your `init.vim`. **All examples are given in Lua,** see `:help
+:lua-heredoc` to use Lua from your init.vim.
 
-## Configurations
+Some configs may define additional server-specific functions, e.g. the `texlab`
+config provides `nvim_lsp.texlab.buf_build({bufnr})`.
 
-The following configurations are implemented:
+### Example: using the defaults
+
+To use the defaults, just call `setup()` with an empty `config` parameter.
+For the `gopls` config, that would be:
+
+    require'nvim_lsp'.gopls.setup{}
+
+### Example: override some defaults
+
+To set some config properties at `setup()`, specify their keys. For example to
+change how the "project root" is found, set the `root_dir` key:
+
+```lua
+local nvim_lsp = require'nvim_lsp'
+nvim_lsp.gopls.setup{
+  root_dir = nvim_lsp.util.root_pattern('.git');
+}
+```
+
+The [documentation](#configurations) for each config lists default values and
+additional optional properties.
+
+```lua
+local nvim_lsp = require'nvim_lsp'
+nvim_lsp.texlab.setup{
+  name = 'texlab_fancy';
+  log_level = vim.lsp.protocol.MessageType.Log;
+  settings = {
+    latex = {
+      build = {
+        onSave = true;
+      }
+    }
+  }
+}
+```
+
+### Example: custom config
+
+To configure a custom/private server, just require `nvim_lsp/skeleton` and do
+the same as we do if we were adding it to the repository itself.
+
+1. Define the config: `configs.foo_lsp = { … }`
+2. Call `nvim_lsp.foo_lsp.setup{}`
+
+```lua
+local nvim_lsp = require'nvim_lsp'
+local configs = require'nvim_lsp/skeleton'
+-- Check if it's already defined for when I reload this file.
+if not nvim_lsp.foo_lsp then
+  configs.foo_lsp = {
+    default_config = {
+      cmd = {'/home/ashkan/works/3rd/lua-language-server/run.sh'};
+      filetypes = {'lua'};
+      root_dir = function(fname)
+        return nvim_lsp.util.find_git_ancestor(fname) or vim.loop.os_homedir()
+      end;
+      log_level = vim.lsp.protocol.MessageType.Warning;
+      settings = {};
+    };
+  }
+end
+nvim_lsp.foo_lsp.setup{}
+```
+
+### Installing a language server
+
+Configs may provide an `install()` function. Then you can use
+`:LspInstall {name}` to install the required language server.
+For example, to install the Elm language server:
+
+    :LspInstall elmls
+
+Use `:LspInstallInfo` to see install info.
+
+    :LspInstallInfo
+
+## setup() function
+
+The `setup()` interface:
+
+```
+nvim_lsp.SERVER.setup{config}
+
+  The `config` parameter has the same shape as that of
+  |vim.lsp.start_client()|, with these additions and changes:
+
+  {root_dir}
+    Required for some servers, optional for others.
+    Function of the form `function(filename, bufnr)`.
+    Called on new candidate buffers being attached-to.
+    Returns either a root_dir or nil.
+
+    If a root_dir is returned, then this file will also be attached. You
+    can optionally use {filetype} to help pre-filter by filetype.
+
+    If a root_dir is returned which is unique from any previously returned
+    root_dir, a new server will be spawned with that root_dir.
+
+    If nil is returned, the buffer is skipped.
+
+    See |nvim_lsp.util.search_ancestors()| and the functions which use it:
+    - |nvim_lsp.util.root_pattern(patterns...)| finds an ancestor which
+    - contains one of the files in `patterns...`. This is equivalent
+      to coc.nvim's "rootPatterns"
+    - Related utilities for common tools:
+      - |nvim_lsp.util.find_git_root()|
+      - |nvim_lsp.util.find_node_modules_root()|
+      - |nvim_lsp.util.find_package_json_root()|
+
+  {name}
+    Defaults to the server's name.
+
+  {filetypes}
+    Set of filetypes to filter for consideration by {root_dir}.
+    May be empty.
+    Server may specify a default value.
+
+  {log_level}
+    controls the level of logs to show from build processes and other
+    window/logMessage events. Defaults to
+    vim.lsp.protocol.MessageType.Warning instead of
+    vim.lsp.protocol.MessageType.Log.
+
+  {settings}
+    Map with case-sensitive keys corresponding to `workspace/configuration`
+    event responses.
+    We also notify the server *once* on `initialize` with
+    `workspace/didChangeConfiguration`.
+    If you change the settings later on, you must emit the notification
+    with `client.workspace_did_change_configuration({settings})`
+    Example: `settings = { keyName = { subKey = 1 } }`
+
+  {on_attach}
+    `function(client)` executed with the current buffer as the one the {client}
+    is being attached-to. This is different from
+    |vim.lsp.start_client()|'s on_attach parameter, which passes the {bufnr} as
+    the second parameter instead. Useful for doing buffer-local setup.
+
+  {on_new_config}
+    `function(new_config)` will be executed after a new configuration has been
+    created as a result of {root_dir} returning a unique value. You can use this
+    as an opportunity to further modify the new_config or use it before it is
+    sent to |vim.lsp.start_client()|.
+```
+
+# Configurations
+
+The following LSP configs are included. Follow a link to find documentation for
+that config.
 
 - [bashls](#bashls)
 - [ccls](#ccls)
@@ -75,126 +215,16 @@ The following configurations are implemented:
 - [texlab](#texlab)
 - [tsserver](#tsserver)
 
-### Installing language servers
-
-Some configs provide auto-installation of the required language server via
-`:LspInstall <name>`.  For example, to install the Elm language server:
-
-    :LspInstall elmls
-
-Detailed info is given by `:LspInstallInfo`, which optionally accepts a server
-name. Example:
-
-### Example
-
-nvim-lsp is a Lua plugin, and all code samples below are in Lua. **It's easy to
-call Lua from Vimscript**: see `:help :lua-heredoc`.
-
-```lua
-require 'nvim_lsp'.texlab.setup {
-  name = "texlab_fancy";
-  log_level = vim.lsp.protocol.MessageType.Log;
-  settings = {
-    latex = {
-      build = {
-        onSave = true;
-      }
-    }
-  }
-}
-
-local nvim_lsp = require 'nvim_lsp'
-
--- Customize how to find the root_dir
-nvim_lsp.gopls.setup {
-  root_dir = nvim_lsp.util.root_pattern(".git");
-}
-
--- Build the current buffer.
-require 'nvim_lsp'.texlab.buf_build(0)
-```
-
-### Setup function details
-
-The main setup signature will be:
-
-```
-nvim_lsp.SERVER.setup({config})
-
-  {config} is the same as |vim.lsp.start_client()|, but with some
-  additions and changes:
-
-  {root_dir}
-    May be required (depending on the server).
-    `function(filename, bufnr)` which is called on new candidate buffers to
-    attach to and returns either a root_dir or nil.
-
-    If a root_dir is returned, then this file will also be attached. You
-    can optionally use {filetype} to help pre-filter by filetype.
-
-    If a root_dir is returned which is unique from any previously returned
-    root_dir, a new server will be spawned with that root_dir.
-
-    If nil is returned, the buffer is skipped.
-
-    See |nvim_lsp.util.search_ancestors()| and the functions which use it:
-    - |nvim_lsp.util.root_pattern(patterns...)| finds an ancestor which
-    - contains one of the files in `patterns...`. This is equivalent
-    to coc.nvim's "rootPatterns"
-    - More specific utilities:
-      - |nvim_lsp.util.find_git_root()|
-      - |nvim_lsp.util.find_node_modules_root()|
-      - |nvim_lsp.util.find_package_json_root()|
-
-  {name}
-    Defaults to the server's name.
-
-  {filetypes}
-    A set of filetypes to filter for consideration by {root_dir}.
-    Can be left empty.
-    A server may specify a default value.
-
-  {log_level}
-    controls the level of logs to show from build processes and other
-    window/logMessage events. By default it is set to
-    vim.lsp.protocol.MessageType.Warning instead of
-    vim.lsp.protocol.MessageType.Log.
-
-  {settings}
-    This is a table, and the keys are case sensitive. This is for the
-    `workspace/configuration` event responses.
-    We also notify the server *once* on `initialize` with
-    `workspace/didChangeConfiguration`.
-    If you change the settings later on, you should send the notification
-    yourself with `client.workspace_did_change_configuration({settings})`
-    Example: `settings = { keyName = { subKey = 1 } }`
-
-  {on_attach}
-    `function(client)` will be executed with the current buffer as the
-    one the {client} is being attaching to. This is different from
-    |vim.lsp.start_client()|'s on_attach parameter, which passes the {bufnr} as
-    the second parameter instead. This is useful for running buffer local
-    commands.
-
-  {on_new_config}
-    `function(new_config)` will be executed after a new configuration has been
-    created as a result of {root_dir} returning a unique value. You can use this
-    as an opportunity to further modify the new_config or use it before it is
-    sent to |vim.lsp.start_client()|.
-```
-
-# LSP Implementations
-
 ## bashls
 
 https://github.com/mads-hartmann/bash-language-server
 
 Language server for bash, written using tree sitter in typescript.
 
-Can be installed in neovim with `:LspInstall bashls`
+Can be installed in Nvim with `:LspInstall bashls`
 
 ```lua
-nvim_lsp.bashls.setup({config})
+require'nvim_lsp'.bashls.setup{}
 
   Default Values:
     cmd = { "bash-language-server", "start" }
@@ -611,7 +641,7 @@ This server accepts configuration via the `settings` key.
 </details>
 
 ```lua
-nvim_lsp.ccls.setup({config})
+require'nvim_lsp'.ccls.setup{}
 
   Default Values:
     capabilities = default capabilities, with offsetEncoding utf-8
@@ -634,7 +664,7 @@ as compile_commands.json or, for simpler projects, a compile_flags.txt.
 
 
 ```lua
-nvim_lsp.clangd.setup({config})
+require'nvim_lsp'.clangd.setup{}
 
   Default Values:
     capabilities = default capabilities, with offsetEncoding utf-8
@@ -655,10 +685,10 @@ https://github.com/vscode-langservers/vscode-css-languageserver-bin
 npm install -g vscode-css-languageserver-bin
 ```
 
-Can be installed in neovim with `:LspInstall cssls`
+Can be installed in Nvim with `:LspInstall cssls`
 
 ```lua
-nvim_lsp.cssls.setup({config})
+require'nvim_lsp'.cssls.setup{}
 
   Default Values:
     capabilities = default capabilities, with offsetEncoding utf-8
@@ -689,10 +719,10 @@ https://github.com/rcjsuen/dockerfile-language-server-nodejs
 npm install -g docker-language-server-nodejs
 ```
     
-Can be installed in neovim with `:LspInstall dockerls`
+Can be installed in Nvim with `:LspInstall dockerls`
 
 ```lua
-nvim_lsp.dockerls.setup({config})
+require'nvim_lsp'.dockerls.setup{}
 
   Default Values:
     cmd = { "docker-language-server", "--stdio" }
@@ -706,12 +736,12 @@ nvim_lsp.dockerls.setup({config})
 
 https://github.com/elm-tooling/elm-language-server#installation
 
-If you don't want to use neovim to install it, then you can use:
+If you don't want to use Nvim to install it, then you can use:
 ```sh
 npm install -g elm elm-test elm-format @elm-tooling/elm-language-server
 ```
 
-Can be installed in neovim with `:LspInstall elmls`
+Can be installed in Nvim with `:LspInstall elmls`
 This server accepts configuration via the `settings` key.
 <details><summary>Available settings:</summary>
 
@@ -748,7 +778,7 @@ This server accepts configuration via the `settings` key.
 </details>
 
 ```lua
-nvim_lsp.elmls.setup({config})
+require'nvim_lsp'.elmls.setup{}
 
   Default Values:
     capabilities = default capabilities, with offsetEncoding utf-8
@@ -782,7 +812,7 @@ npm run flow lsp -- --help
     
 
 ```lua
-nvim_lsp.flow.setup({config})
+require'nvim_lsp'.flow.setup{}
 
   Default Values:
     cmd = { "npm", "run", "flow", "lsp" }
@@ -870,7 +900,7 @@ This server accepts configuration via the `settings` key.
 </details>
 
 ```lua
-nvim_lsp.fortls.setup({config})
+require'nvim_lsp'.fortls.setup{}
 
   Default Values:
     cmd = { "fortls" }
@@ -906,7 +936,7 @@ This server accepts configuration via the `settings` key.
 </details>
 
 ```lua
-nvim_lsp.ghcide.setup({config})
+require'nvim_lsp'.ghcide.setup{}
 
   Default Values:
     cmd = { "ghcide", "--lsp" }
@@ -924,7 +954,7 @@ Google's lsp server for golang.
 
 
 ```lua
-nvim_lsp.gopls.setup({config})
+require'nvim_lsp'.gopls.setup{}
 
   Default Values:
     cmd = { "gopls" }
@@ -1047,7 +1077,7 @@ This server accepts configuration via the `settings` key.
 </details>
 
 ```lua
-nvim_lsp.hie.setup({config})
+require'nvim_lsp'.hie.setup{}
 
   Default Values:
     cmd = { "hie-wrapper" }
@@ -1191,7 +1221,7 @@ This server accepts configuration via the `settings` key.
 </details>
 
 ```lua
-nvim_lsp.leanls.setup({config})
+require'nvim_lsp'.leanls.setup{}
 
   Default Values:
     cmd = { "lean-language-server", "--stdio" }
@@ -1473,7 +1503,7 @@ This server accepts configuration via the `settings` key.
 </details>
 
 ```lua
-nvim_lsp.pyls.setup({config})
+require'nvim_lsp'.pyls.setup{}
 
   Default Values:
     cmd = { "pyls" }
@@ -1485,13 +1515,13 @@ nvim_lsp.pyls.setup({config})
 
 ## pyls_ms
 
-    https://github.com/Microsoft/python-language-server
-    `python-language-server`, a language server for Python.
+https://github.com/Microsoft/python-language-server
+`python-language-server`, a language server for Python.
     
-Can be installed in neovim with `:LspInstall pyls_ms`
+Can be installed in Nvim with `:LspInstall pyls_ms`
 
 ```lua
-nvim_lsp.pyls_ms.setup({config})
+require'nvim_lsp'.pyls_ms.setup{}
 
   Default Values:
     filetypes = { "python" }
@@ -1526,11 +1556,8 @@ https://github.com/rust-lang/rls
 
 rls, a language server for Rust
 
-Refer to the following for how to setup rls itself.
-https://github.com/rust-lang/rls#setup
-
-See below for rls specific settings.
-https://github.com/rust-lang/rls#configuration
+See https://github.com/rust-lang/rls#setup to setup rls itself.
+See https://github.com/rust-lang/rls#configuration for rls-specific settings.
 
 If you want to use rls for a particular build, eg nightly, set cmd as follows:
 
@@ -1741,7 +1768,7 @@ This server accepts configuration via the `settings` key.
 </details>
 
 ```lua
-nvim_lsp.rls.setup({config})
+require'nvim_lsp'.rls.setup{}
 
   Default Values:
     cmd = { "rls" }
@@ -1755,10 +1782,10 @@ nvim_lsp.rls.setup({config})
 
 https://github.com/rust-analyzer/rust-analyzer
 
-rust-analyzer(aka rls 2.0), a language server for Rust
+rust-analyzer (aka rls 2.0), a language server for Rust
 
-See below for rls specific settings.
-https://github.com/rust-analyzer/rust-analyzer/tree/master/docs/user#settings
+See [rls docs](https://github.com/rust-lang/rls#configuration) for rls-specific settings.
+
     
 This server accepts configuration via the `settings` key.
 <details><summary>Available settings:</summary>
@@ -1856,7 +1883,7 @@ This server accepts configuration via the `settings` key.
 </details>
 
 ```lua
-nvim_lsp.rust_analyzer.setup({config})
+require'nvim_lsp'.rust_analyzer.setup{}
 
   Default Values:
     capabilities = {
@@ -2020,7 +2047,7 @@ This server accepts configuration via the `settings` key.
 </details>
 
 ```lua
-nvim_lsp.solargraph.setup({config})
+require'nvim_lsp'.solargraph.setup{}
 
   Default Values:
     cmd = { "solargraph", "stdio" }
@@ -2039,7 +2066,7 @@ because it doesn't provide a global binary. We provide an installer for Linux
 using `:LspInstall`.  If you wish to install it yourself, [here is a
 guide](https://github.com/sumneko/lua-language-server/wiki/Build-and-Run).
 
-Can be installed in neovim with `:LspInstall sumneko_lua`
+Can be installed in Nvim with `:LspInstall sumneko_lua`
 This server accepts configuration via the `settings` key.
 <details><summary>Available settings:</summary>
 
@@ -2114,7 +2141,7 @@ This server accepts configuration via the `settings` key.
 </details>
 
 ```lua
-nvim_lsp.sumneko_lua.setup({config})
+require'nvim_lsp'.sumneko_lua.setup{}
 
   Default Values:
     filetypes = { "lua" }
@@ -2133,7 +2160,7 @@ See https://texlab.netlify.com/docs/reference/configuration for configuration op
 
 
 ```lua
-nvim_lsp.texlab.setup({config})
+require'nvim_lsp'.texlab.setup{}
 
   Commands:
   - TexlabBuild: Build the current buffer
@@ -2175,10 +2202,10 @@ https://github.com/theia-ide/typescript-language-server
 npm install -g typescript-language-server
 ```
 
-Can be installed in neovim with `:LspInstall tsserver`
+Can be installed in Nvim with `:LspInstall tsserver`
 
 ```lua
-nvim_lsp.tsserver.setup({config})
+require'nvim_lsp'.tsserver.setup{}
 
   Default Values:
     capabilities = default capabilities, with offsetEncoding utf-8

--- a/autoload/nvim_lsp.vim
+++ b/autoload/nvim_lsp.vim
@@ -1,3 +1,0 @@
-function! nvim_lsp#setup(name, config)
-  return luaeval("require'nvim_lsp'[_A[1]].setup(_A[2])", [a:name, a:config])
-endfunction

--- a/lua/nvim_lsp/elmls.lua
+++ b/lua/nvim_lsp/elmls.lua
@@ -57,7 +57,7 @@ skeleton[server_name] = {
     description = [[
 https://github.com/elm-tooling/elm-language-server#installation
 
-If you don't want to use neovim to install it, then you can use:
+If you don't want to use Nvim to install it, then you can use:
 ```sh
 npm install -g elm elm-test elm-format @elm-tooling/elm-language-server
 ```

--- a/lua/nvim_lsp/pyls_ms.lua
+++ b/lua/nvim_lsp/pyls_ms.lua
@@ -113,8 +113,8 @@ skeleton[name] = {
   -- on_attach = function(client, bufnr) end;
   docs = {
     description = [[
-    https://github.com/Microsoft/python-language-server
-    `python-language-server`, a language server for Python.
+https://github.com/Microsoft/python-language-server
+`python-language-server`, a language server for Python.
     ]];
     default_config = {
       root_dir = "vim's starting directory";

--- a/lua/nvim_lsp/rls.lua
+++ b/lua/nvim_lsp/rls.lua
@@ -18,11 +18,8 @@ https://github.com/rust-lang/rls
 
 rls, a language server for Rust
 
-Refer to the following for how to setup rls itself.
-https://github.com/rust-lang/rls#setup
-
-See below for rls specific settings.
-https://github.com/rust-lang/rls#configuration
+See https://github.com/rust-lang/rls#setup to setup rls itself.
+See https://github.com/rust-lang/rls#configuration for rls-specific settings.
 
 If you want to use rls for a particular build, eg nightly, set cmd as follows:
 

--- a/lua/nvim_lsp/rust_analyzer.lua
+++ b/lua/nvim_lsp/rust_analyzer.lua
@@ -15,10 +15,10 @@ skeleton.rust_analyzer = {
     description = [[
 https://github.com/rust-analyzer/rust-analyzer
 
-rust-analyzer(aka rls 2.0), a language server for Rust
+rust-analyzer (aka rls 2.0), a language server for Rust
 
-See below for rls specific settings.
-https://github.com/rust-analyzer/rust-analyzer/tree/master/docs/user#settings
+See [rls docs](https://github.com/rust-lang/rls#configuration) for rls-specific settings.
+
     ]];
     default_config = {
       root_dir = [[root_pattern("Cargo.toml")]];

--- a/lua/nvim_lsp/skeleton.lua
+++ b/lua/nvim_lsp/skeleton.lua
@@ -40,7 +40,7 @@ function skeleton.__newindex(t, template_name, template)
     config.callbacks["window/logMessage"] = function(err, method, params, client_id)
       if params and params.type <= config.log_level then
         -- TODO(ashkan) remove this after things have settled.
-        assert(lsp.callbacks, "Please update neovim master. This is an incompatible interface.")
+        assert(lsp.callbacks, "Update to Nvim HEAD. This is an incompatible interface.")
         lsp.callbacks[method](err, method, params, client_id)
       end
     end

--- a/lua/nvim_lsp/util.lua
+++ b/lua/nvim_lsp/util.lua
@@ -327,7 +327,7 @@ function M.npm_installer(config)
   local function install()
     -- TODO(ashkan) need all binaries or just the first?
     if M.has_bins(unpack(config.binaries)) then
-      return print(config.server_name, "is already installed (not by neovim)")
+      return print(config.server_name, "is already installed (not by Nvim)")
     end
     if not M.has_bins("sh", "npm", "mkdir") then
       api.nvim_err_writeln('Installation requires "sh", "npm", "mkdir"')

--- a/scripts/docgen.lua
+++ b/scripts/docgen.lua
@@ -68,8 +68,7 @@ local lsp_section_template = [[
 
 {{preamble}}
 ```lua
-nvim_lsp.{{template_name}}.setup({config})
-nvim_lsp#setup("{{template_name}}", {config})
+require'nvim_lsp'.{{template_name}}.setup{}
 
 {{body}}
 ```
@@ -124,7 +123,7 @@ local function make_lsp_sections()
         end;
         function()
           if template_object.install then
-            return string.format("Can be installed in neovim with `:LspInstall %s`", template_name)
+            return string.format("Can be installed in Nvim with `:LspInstall %s`", template_name)
           end
         end;
         function()


### PR DESCRIPTION
- Revise docs for brevity/clarity/concision.
- Add section for "custom server" #41
- Remove Vimscript wrapper. Lua is easy to use from Vimscript, there is no reason to have multiple ways to work with nvim-lsp.
  - massively clarifies the "story" that users need to comprehend
  - reduces surface area, maintenance, tests
  - avoids constant "Vim or Lua" dance in the documentation
  - simplifies discussions, tutorials, etc.
  - avoids confusing situation for users that start with Vimscript but
    later need Lua-only features

