### PR TITLE
Fix typo in docgen.lua

### DIFF
--- a/scripts/docgen.lua
+++ b/scripts/docgen.lua
@@ -68,7 +68,7 @@ local lsp_section_template = [[
 
 {{preamble}}
 ```lua
-require'nvim_lsp'.{{template_name}}.setup{}
+require 'nvim_lsp'.{{template_name}}.setup{}
 
 {{body}}
 ```


### PR DESCRIPTION
Small typo in the template for each language server's preamble.