### PR TITLE
skeleton.lua: fixup client initialize process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1279,7 +1279,7 @@ This server accepts configuration via the `settings` key.
 
 - **`lean.input.customTranslations`**: `object`
 
-  Default: `{}`
+  Default: `vim.empty_dict()`
   
   Array items: `{description = "Unicode character to translate to",type = "string"}`
   
@@ -2006,7 +2006,7 @@ This server accepts configuration via the `settings` key.
 
 - **`rust-analyzer.featureFlags`**: `object`
 
-  Default: `{}`
+  Default: `vim.empty_dict()`
   
   Fine grained feature flags to disable annoying features
 

--- a/lua/nvim_lsp/skeleton.lua
+++ b/lua/nvim_lsp/skeleton.lua
@@ -27,6 +27,7 @@ function skeleton.__newindex(t, template_name, template)
   local default_config = tbl_extend("keep", template.default_config, {
     log_level = lsp.protocol.MessageType.Warning;
     settings = {};
+    init_options = {};
     callbacks = {};
   })
 
@@ -98,6 +99,9 @@ function skeleton.__newindex(t, template_name, template)
       new_config.settings = vim.deepcopy(new_config.settings)
       util.tbl_deep_extend(new_config.settings, default_config.settings)
 
+      new_config.init_options = vim.deepcopy(new_config.init_options)
+      util.tbl_deep_extend(new_config.init_options, default_config.init_options)
+
       new_config.capabilities = new_config.capabilities or lsp.protocol.make_client_capabilities()
       util.tbl_deep_extend(new_config.capabilities, {
         workspace = {
@@ -123,7 +127,7 @@ function skeleton.__newindex(t, template_name, template)
             settings = settings;
           })
         end
-        if new_config.settings then
+        if not vim.tbl_isempty(new_config.settings) then
           client.workspace_did_change_configuration(new_config.settings)
         end
       end)


### PR DESCRIPTION
Nvim built-in lsp client can handle `initializeOptions` as init_options.
But nvim-lsp can't give init_options to lsp.start_client.

Not all language servers implement `workspace/didChangeConfiguration` now .(ex, gopls)
If we use those servers, we get 'not yet implement' error message.
So if config.settings is empty list, we don't request `workspace/didChangeConfiguration`.

![2020_01_02_1740-1577954418_](https://user-images.githubusercontent.com/4556097/71658346-0a029e00-2d87-11ea-9eab-808c3db79d75.png)