### PR TITLE
Overwrite only when the value of dst is falsy

### DIFF
--- a/lua/nvim_lsp/util.lua
+++ b/lua/nvim_lsp/util.lua
@@ -47,7 +47,7 @@ function M.tbl_deep_extend(dst, ...)
       if type(v) == 'table' and not vim.tbl_islist(v) then
         dst[k] = M.tbl_deep_extend(dst[k] or vim.empty_dict(), v)
       else
-        dst[k] = v
+        dst[k] = dst[k] or v
       end
     end
   end


### PR DESCRIPTION
I found this when I attempt to set `init_options` for pyls_ms.

```lua
require'nvim_lsp'.pyls_ms.setup{
  init_options = {
    interpreter = {
      properties = {
        InterpreterPath = '/usr/bin/python3';
        Version = '3.6.9';
      }
    }
  }
}
```

But with this, `new_config` still has the default value from [here][].

[here]: https://github.com/neovim/nvim-lsp/blob/7a15a52c0a7d735625ac73dc4d8efe70c5e99707/lua/nvim_lsp/pyls_ms.lua#L99-L111