### PR TITLE
Update coursier url

### DIFF
--- a/lua/nvim_lsp/metals.lua
+++ b/lua/nvim_lsp/metals.lua
@@ -23,7 +23,7 @@ local function make_installer()
       return
     end
     local coursier_bin = install_dir .. "/coursier"
-    local download_cmd = string.format("curl -fLo %s --create-dirs https://git.io/coursier", coursier_bin)
+    local download_cmd = string.format("curl -fLo %s --create-dirs https://git.io/coursier-cli", coursier_bin)
     local chmod_cmd = string.format("chmod +x %s", coursier_bin)
     local install_cmd = string.format("%s bootstrap --java-opt -Xss4m --java-opt -Xms100m --java-opt -Dmetals.client=coc.nvim org.scalameta:metals_2.12:latest.release -r bintray:scalacenter/releases -r sonatype:snapshots -o %s -f", coursier_bin, metals_bin)
     vim.fn.system(download_cmd)


### PR DESCRIPTION
Previously the curl to coursier would work, however, it would bring in an old version of coursier where the `latest.version` command to pull in the artifact doesn't work. You can test this by trying to do a `:LspInstall metal`, which will download coursier, but not actually download metals. This change is a small one which will follow the curl instructions found [here on the site](https://get-coursier.io/docs/cli-overview.html#curl) targeting `coursier-cli`, which is what we want, which has the ability to correctly target `latest.version`.