### PR TITLE
fix nvim-lsp for rust_analyzer according to protocol

### DIFF
--- a/lua/nvim_lsp/skeleton.lua
+++ b/lua/nvim_lsp/skeleton.lua
@@ -27,7 +27,7 @@ function skeleton.__newindex(t, template_name, template)
   local default_config = tbl_extend("keep", template.default_config, {
     log_level = lsp.protocol.MessageType.Warning;
     settings = {};
-    init_options = {};
+    init_options = vim.empty_dict();
     callbacks = {};
   })
 


### PR DESCRIPTION
NOTE: testing for non-rust settings needed, error message might still shortly appear for a few milliseconds