### PR TITLE
docgen.lua: require language server modules

### DIFF
--- a/scripts/docgen.lua
+++ b/scripts/docgen.lua
@@ -222,6 +222,14 @@ local function make_lsp_sections()
 end
 
 local function make_implemented_servers_list()
+  -- load language server modules
+  local pfile = io.popen('ls lua/nvim_lsp/')
+  for filename in pfile:lines() do
+      local f = string.gsub(filename, ".lua$", "", 1)
+      require("../lua/nvim_lsp/"..f)
+  end
+  pfile:close()
+
   return make_section(0, '\n', sorted_map_table(configs, function(k)
     return template("- [{{server}}](#{{server}})", {server=k})
   end))


### PR DESCRIPTION
In # 109, when loading nvim_lsp.lua, all the language server lua modules were not loaded,
so the language server module was missing from the configs module referenced in docgen.
So require the language server module in docgen.lua.
configs.lua and utils.lua are also required, but they have no effect as they do not add themselves to the configs module.