### PR TITLE
[RDY] checkhealth: add checkhealth nvim_lsp command

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+tab_width = 8
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[{Makefile,**/Makefile,runtime/doc/*.txt}]
+indent_style = tab
+indent_size = 8

--- a/autoload/health/nvim_lsp.vim
+++ b/autoload/health/nvim_lsp.vim
@@ -1,0 +1,4 @@
+function! health#nvim_lsp#check()
+  call health#report_start('Checking language server protocol configuration')
+  lua require 'nvim_lsp/health'.check_health()
+endfunction

--- a/lua/nvim_lsp/configs.lua
+++ b/lua/nvim_lsp/configs.lua
@@ -93,7 +93,8 @@ function configs.__newindex(t, config_name, config_def)
       end
       M.manager = nil
     end
-    local manager = util.server_per_root_dir_manager(function(_root_dir)
+
+    local make_config = function(_root_dir)
       local new_config = vim.tbl_extend("keep", {}, config)
       -- Deepcopy anything that is >1 level nested.
       new_config.settings = vim.deepcopy(new_config.settings)
@@ -146,8 +147,14 @@ function configs.__newindex(t, config_name, config_def)
               ))
         end
       end)
+
+      new_config.root_dir = _root_dir
       return new_config
-    end)
+    end
+
+    local manager = util.server_per_root_dir_manager(function(_root_dir)
+        return make_config(_root_dir)
+      end)
 
     function manager.try_add()
       local root_dir = get_root_dir(api.nvim_buf_get_name(0), api.nvim_get_current_buf())
@@ -159,6 +166,7 @@ function configs.__newindex(t, config_name, config_def)
     end
 
     M.manager = manager
+    M.make_config = make_config
   end
 
   function M._setup_buffer(client_id)

--- a/lua/nvim_lsp/health.lua
+++ b/lua/nvim_lsp/health.lua
@@ -1,0 +1,22 @@
+local M = {}
+function M.check_health()
+  local configs = require 'nvim_lsp/configs'
+
+  for _, top_level_config in pairs(configs) do
+    -- the folder needs to exist
+    local new_config = top_level_config.make_config(".")
+
+    local cmd, _ = vim.lsp._cmd_parts(new_config.cmd)
+    if not (vim.fn.executable(cmd) == 1) then
+      vim.fn['health#report_error'](
+        string.format("%s: The given command %q is not executable.", new_config.name, cmd)
+      )
+    else
+      vim.fn['health#report_info'](
+        string.format("%s: configuration checked.", new_config.name)
+      )
+    end
+  end
+end
+
+return M

--- a/lua/nvim_lsp/util.lua
+++ b/lua/nvim_lsp/util.lua
@@ -208,7 +208,7 @@ end)()
 
 -- Returns a function(root_dir), which, when called with a root_dir it hasn't
 -- seen before, will call make_config(root_dir) and start a new client.
-function M.server_per_root_dir_manager(make_config)
+function M.server_per_root_dir_manager(_make_config)
   local clients = {}
   local manager = {}
 
@@ -218,8 +218,7 @@ function M.server_per_root_dir_manager(make_config)
     -- Check if we have a client alredy or start and store it.
     local client_id = clients[root_dir]
     if not client_id then
-      local new_config = make_config(root_dir)
-      new_config.root_dir = root_dir
+      local new_config = _make_config(root_dir)
       new_config.on_exit = M.add_hook_before(new_config.on_exit, function()
         clients[root_dir] = nil
       end)


### PR DESCRIPTION
Only check command for now.

This was much harder than expected as it's dynamically typed, the generation of the config and the start of the client is intertwined, and the logic for merging configs is very good but not the easiest to grasp.

It needs https://github.com/neovim/neovim/pull/11832 to work.

And gives this output:
```
health#nvim_lsp#check
========================================================================
## Checking language server protocol configuration
  - INFO: Checking pyls
  - ERROR: The given command "python" is not executable.
  - INFO: Checking ccls
  - INFO: Checking lua_lsp
  - INFO: Checking ghcide
  - ERROR: The given command "ghcide" is not executable.
  - INFO: Checking texlab
  - ERROR: The given command "texlab" is not executable.
```
It's primitive but it's easy to improve. just check the attributes of new_config.