### PR TITLE
Use vim.empty_dict() instead of {}

### DIFF
--- a/lua/nvim_lsp/bashls.lua
+++ b/lua/nvim_lsp/bashls.lua
@@ -17,7 +17,6 @@ configs[server_name] = {
     filetypes = {"sh"};
     root_dir = vim.loop.os_homedir;
     log_level = lsp.protocol.MessageType.Warning;
-    settings = {};
   };
   on_new_config = function(new_config)
     local install_info = installer.info()

--- a/lua/nvim_lsp/ccls.lua
+++ b/lua/nvim_lsp/ccls.lua
@@ -8,7 +8,6 @@ configs.ccls = {
     filetypes = {"c", "cpp", "objc", "objcpp"};
     root_dir = util.root_pattern("compile_commands.json", "compile_flags.txt", ".git");
     log_level = lsp.protocol.MessageType.Warning;
-    settings = {};
   };
   -- commands = {};
   -- on_new_config = function(new_config) end;

--- a/lua/nvim_lsp/clangd.lua
+++ b/lua/nvim_lsp/clangd.lua
@@ -11,7 +11,6 @@ configs.clangd = {
       return root_pattern(fname) or util.path.dirname(fname)
     end;
     log_level = lsp.protocol.MessageType.Warning;
-    settings = {};
   };
   -- commands = {};
   -- on_new_config = function(new_config) end;

--- a/lua/nvim_lsp/configs.lua
+++ b/lua/nvim_lsp/configs.lua
@@ -26,7 +26,7 @@ function configs.__newindex(t, config_name, config_def)
 
   local default_config = tbl_extend("keep", config_def.default_config, {
     log_level = lsp.protocol.MessageType.Warning;
-    settings = {};
+    settings = vim.empty_dict();
     init_options = vim.empty_dict();
     callbacks = {};
   })
@@ -95,7 +95,7 @@ function configs.__newindex(t, config_name, config_def)
     end
 
     local make_config = function(_root_dir)
-      local new_config = vim.tbl_extend("keep", {}, config)
+      local new_config = vim.tbl_extend("keep", vim.empty_dict(), config)
       -- Deepcopy anything that is >1 level nested.
       new_config.settings = vim.deepcopy(new_config.settings)
       util.tbl_deep_extend(new_config.settings, default_config.settings)
@@ -153,8 +153,8 @@ function configs.__newindex(t, config_name, config_def)
     end
 
     local manager = util.server_per_root_dir_manager(function(_root_dir)
-        return make_config(_root_dir)
-      end)
+      return make_config(_root_dir)
+    end)
 
     function manager.try_add()
       local root_dir = get_root_dir(api.nvim_buf_get_name(0), api.nvim_get_current_buf())

--- a/lua/nvim_lsp/dartls.lua
+++ b/lua/nvim_lsp/dartls.lua
@@ -47,7 +47,6 @@ configs[server_name] = {
       outline = "true",
       fluttreOutline= "false"
     };
-    settings = {};
   };
   docs = {
     vscode = "Dart-Code.dart-code";

--- a/lua/nvim_lsp/dockerls.lua
+++ b/lua/nvim_lsp/dockerls.lua
@@ -17,7 +17,6 @@ configs[server_name] = {
     filetypes = {"Dockerfile", "dockerfile"};
     root_dir = util.root_pattern("Dockerfile");
     log_level = lsp.protocol.MessageType.Warning;
-    settings = {};
   };
   on_new_config = function(new_config)
     local install_info = installer.info()

--- a/lua/nvim_lsp/elmls.lua
+++ b/lua/nvim_lsp/elmls.lua
@@ -28,7 +28,6 @@ configs[server_name] = {
       end
     end;
     log_level = lsp.protocol.MessageType.Warning;
-    settings = {};
     init_options = {
       elmPath = "elm",
       elmFormatPath = "elm-format",

--- a/lua/nvim_lsp/flow.lua
+++ b/lua/nvim_lsp/flow.lua
@@ -8,7 +8,6 @@ configs.flow = {
     filetypes = {"javascript", "javascriptreact", "javascript.jsx"};
     root_dir = util.root_pattern(".flowconfig");
     log_level = lsp.protocol.MessageType.Warning;
-    settings = {};
   };
   docs = {
     package_json = "https://raw.githubusercontent.com/flowtype/flow-for-vscode/master/package.json";

--- a/lua/nvim_lsp/ghcide.lua
+++ b/lua/nvim_lsp/ghcide.lua
@@ -8,7 +8,6 @@ configs.ghcide = {
     filetypes = { "haskell", "lhaskell" };
     root_dir = util.root_pattern("stack.yaml", "hie-bios", "BUILD.bazel", "cabal.config", "package.yaml");
     log_level = lsp.protocol.MessageType.Warning;
-    settings = {};
   };
 
   docs = {

--- a/lua/nvim_lsp/gopls.lua
+++ b/lua/nvim_lsp/gopls.lua
@@ -8,7 +8,6 @@ configs.gopls = {
     filetypes = {"go"};
     root_dir = util.root_pattern("go.mod", ".git");
     log_level = lsp.protocol.MessageType.Warning;
-    settings = {};
   };
   -- on_new_config = function(new_config) end;
   -- on_attach = function(client, bufnr) end;

--- a/lua/nvim_lsp/hie.lua
+++ b/lua/nvim_lsp/hie.lua
@@ -8,7 +8,6 @@ configs.hie = {
     filetypes = {"haskell"};
     root_dir = util.root_pattern("stack.yaml", "package.yaml", ".git");
     log_level = lsp.protocol.MessageType.Warning;
-    settings = {};
   };
 
   docs = {

--- a/lua/nvim_lsp/jsonls.lua
+++ b/lua/nvim_lsp/jsonls.lua
@@ -17,7 +17,6 @@ configs[server_name] = {
     filetypes = {"json"};
     root_dir = util.root_pattern(".git", vim.fn.getcwd());
     log_level = lsp.protocol.MessageType.Warning;
-    settings = {};
   };
   on_new_config = function(new_config)
     local install_info = installer.info()

--- a/lua/nvim_lsp/julials.lua
+++ b/lua/nvim_lsp/julials.lua
@@ -13,7 +13,6 @@ configs.julials = {
     };
     filetypes = {'julia'};
     log_level = vim.lsp.protocol.MessageType.Warning;
-    settings = {};
     root_dir = function(fname)
       return util.find_git_ancestor(fname) or vim.loop.os_homedir()
     end;

--- a/lua/nvim_lsp/leanls.lua
+++ b/lua/nvim_lsp/leanls.lua
@@ -8,7 +8,6 @@ configs.leanls = {
     filetypes = {"lean"};
     root_dir = util.root_pattern(".git");
     log_level = lsp.protocol.MessageType.Warning;
-    settings = {};
   };
   -- on_new_config = function(new_config) end;
   -- on_attach = function(client, bufnr) end;

--- a/lua/nvim_lsp/metals.lua
+++ b/lua/nvim_lsp/metals.lua
@@ -54,7 +54,6 @@ configs[server_name] = {
     filetype = {"scala"};
     root_dir = util.root_pattern("build.sbt", "build.sc", "build.gradle", "pom.xml");
     log_level = lsp.protocol.MessageType.Warning;
-    settings = {};
   };
   on_new_config = function(config)
     installer.configure(config)

--- a/lua/nvim_lsp/ocamlls.lua
+++ b/lua/nvim_lsp/ocamlls.lua
@@ -17,7 +17,6 @@ configs[server_name] = {
     filetypes = { "ocaml", "reason" };
     root_dir = util.root_pattern(".merlin", "package.json");
     log_level = lsp.protocol.MessageType.Warning;
-    settings = {};
   };
   on_new_config = function(new_config)
     local install_info = installer.info()

--- a/lua/nvim_lsp/pyls.lua
+++ b/lua/nvim_lsp/pyls.lua
@@ -7,7 +7,6 @@ configs.pyls = {
     filetypes = {"python"};
     root_dir = vim.loop.os_homedir;
     log_level = lsp.protocol.MessageType.Warning;
-    settings = {};
   };
   -- on_new_config = function(new_config) end;
   -- on_attach = function(client, bufnr) end;

--- a/lua/nvim_lsp/rls.lua
+++ b/lua/nvim_lsp/rls.lua
@@ -8,7 +8,6 @@ configs.rls = {
     filetypes = {"rust"};
     root_dir = util.root_pattern("Cargo.toml");
     log_level = lsp.protocol.MessageType.Warning;
-    settings = {};
   };
   docs = {
     vscode = "rust-lang.rust";

--- a/lua/nvim_lsp/rust_analyzer.lua
+++ b/lua/nvim_lsp/rust_analyzer.lua
@@ -8,7 +8,6 @@ configs.rust_analyzer = {
     filetypes = {"rust"};
     root_dir = util.root_pattern("Cargo.toml");
     log_level = lsp.protocol.MessageType.Warning;
-    settings = {};
   };
   docs = {
     package_json = "https://github.com/rust-analyzer/rust-analyzer/raw/master/editors/code/package.json";

--- a/lua/nvim_lsp/solargraph.lua
+++ b/lua/nvim_lsp/solargraph.lua
@@ -8,7 +8,6 @@ configs.solargraph = {
     filetypes = {"ruby"};
     root_dir = util.root_pattern("Gemfile", ".git");
     log_level = lsp.protocol.MessageType.Warning;
-    settings = {};
   };
   docs = {
     vscode = "castwide.solargraph";

--- a/lua/nvim_lsp/sumneko_lua.lua
+++ b/lua/nvim_lsp/sumneko_lua.lua
@@ -99,7 +99,6 @@ configs[name] = {
       return util.find_git_ancestor(fname) or vim.loop.os_homedir()
     end;
     log_level = vim.lsp.protocol.MessageType.Warning;
-    settings = {};
   };
   on_new_config = function(config)
     installer.configure(config)

--- a/lua/nvim_lsp/terraformls.lua
+++ b/lua/nvim_lsp/terraformls.lua
@@ -8,7 +8,6 @@ configs.terraformls = {
     filetypes = {"terraform"};
     root_dir = util.root_pattern(".git");
     log_level = lsp.protocol.MessageType.Warning;
-    settings = {};
   };
   docs = {
     vscode = "mauve.terraform";

--- a/lua/nvim_lsp/tsserver.lua
+++ b/lua/nvim_lsp/tsserver.lua
@@ -17,7 +17,6 @@ configs[server_name] = {
     filetypes = {"javascript", "javascriptreact", "javascript.jsx", "typescript", "typescriptreact", "typescript.tsx"};
     root_dir = util.root_pattern("package.json");
     log_level = lsp.protocol.MessageType.Warning;
-    settings = {};
   };
   on_new_config = function(new_config)
     local install_info = installer.info()

--- a/lua/nvim_lsp/util.lua
+++ b/lua/nvim_lsp/util.lua
@@ -45,7 +45,7 @@ function M.tbl_deep_extend(dst, ...)
     validate { arg = { t, 't' } }
     for k, v in pairs(t) do
       if type(v) == 'table' and not vim.tbl_islist(v) then
-        dst[k] = M.tbl_deep_extend(dst[k] or {}, v)
+        dst[k] = M.tbl_deep_extend(dst[k] or vim.empty_dict(), v)
       else
         dst[k] = v
       end

--- a/lua/nvim_lsp/vimls.lua
+++ b/lua/nvim_lsp/vimls.lua
@@ -19,7 +19,6 @@ configs[server_name] = {
       return util.find_git_ancestor(fname) or vim.loop.os_homedir()
     end,
     log_level = lsp.protocol.MessageType.Warning,
-    settings = {},
     init_options = {
       iskeyword = "@,48-57,_,192-255,-#",
       vimruntime = "",

--- a/lua/nvim_lsp/yamlls.lua
+++ b/lua/nvim_lsp/yamlls.lua
@@ -17,7 +17,6 @@ configs[server_name] = {
     filetypes = {"yaml"};
     root_dir = util.root_pattern(".git", vim.fn.getcwd());
     log_level = lsp.protocol.MessageType.Warning;
-    settings = {};
   };
   on_new_config = function(new_config)
     local install_info = installer.info()


### PR DESCRIPTION
fix: #94
rust-analyzer parses initializeOptions according to the type definition.
Therefore, an empty dictionary fails because it does not satisfy the type definition.
So, set the default value of ServerConfig type to initializeOptions.

https://github.com/rust-analyzer/rust-analyzer/blob/d8d8c20077702b8537086d49914d02654a46ebc5/crates/ra_lsp_server/src/main.rs#L65-L79
https://github.com/rust-analyzer/rust-analyzer/blob/dc48f89581843248660ceb755bb20469ab6ac0c9/crates/ra_lsp_server/src/config.rs#L18-L49