### PR TITLE
Add GDScript support

### DIFF
--- a/lua/nvim_lsp/gdscript.lua
+++ b/lua/nvim_lsp/gdscript.lua
@@ -9,8 +9,6 @@ configs.gdscript = {
     root_dir = util.root_pattern("project.godot", ".git");
     log_level = lsp.protocol.MessageType.Warning;
   };
-  -- on_new_config = function(new_config) end;
-  -- on_attach = function(client, bufnr) end;
   docs = {
     description = [[
 https://github.com/godotengine/godot
@@ -18,7 +16,7 @@ https://github.com/godotengine/godot
 Language server for GDScript, used by Godot Engine.
 ]];
     default_config = {
-      root_dir = "vim's starting directory";
+      root_dir = util.root_pattern("project.godot", ".git");
     };
   };
 };

--- a/lua/nvim_lsp/gdscript.lua
+++ b/lua/nvim_lsp/gdscript.lua
@@ -1,13 +1,11 @@
 local configs = require 'nvim_lsp/configs'
 local util = require 'nvim_lsp/util'
-local lsp = vim.lsp
 
 configs.gdscript = {
   default_config = {
     cmd = {"nc", "localhost", "6008"};
     filetypes = {"gd", "gdscript3"};
     root_dir = util.root_pattern("project.godot", ".git");
-    log_level = lsp.protocol.MessageType.Warning;
   };
   docs = {
     description = [[

--- a/lua/nvim_lsp/gdscript.lua
+++ b/lua/nvim_lsp/gdscript.lua
@@ -1,0 +1,26 @@
+local configs = require 'nvim_lsp/configs'
+local util = require 'nvim_lsp/util'
+local lsp = vim.lsp
+
+configs.gdscript = {
+  default_config = {
+    cmd = {"nc", "localhost", "6008"};
+    filetypes = {"gd", "gdscript3"};
+    root_dir = util.root_pattern("project.godot", ".git");
+    log_level = lsp.protocol.MessageType.Warning;
+  };
+  -- on_new_config = function(new_config) end;
+  -- on_attach = function(client, bufnr) end;
+  docs = {
+    description = [[
+https://github.com/godotengine/godot
+
+Language server for GDScript, used by Godot Engine.
+]];
+    default_config = {
+      root_dir = "vim's starting directory";
+    };
+  };
+};
+
+-- vim:et ts=2 sw=2


### PR DESCRIPTION
Recently Godot 3.2 was released with LSP support. But LSP works only through Websocket. [This](https://github.com/godotengine/godot/pull/35864#) PR switches Godot's LSP to TCP and now can be supported for the Vim plugins. This PR adds support for upcoming Godot version via `nc` (works only with mentioned PR above).