### PR TITLE
Add CodeQL support

### DIFF
--- a/lua/nvim_lsp/codeqlls.lua
+++ b/lua/nvim_lsp/codeqlls.lua
@@ -24,7 +24,14 @@ configs[server_name] = {
         };
     };
     docs = {
-        description = [[test]]
+        description = [[
+Reference:
+https://help.semmle.com/codeql/codeql-cli.html
+
+Binaries:
+https://github.com/github/codeql-cli-binaries
+        ]];
+        package_json = "https://github.com/github/vscode-codeql/blob/master/extensions/ql-vscode/package.json";
     };
     on_new_config = function(config)
         if config.settings.search_path ~= nil and config.settings.search_path ~= '' then

--- a/lua/nvim_lsp/codeqlls.lua
+++ b/lua/nvim_lsp/codeqlls.lua
@@ -5,8 +5,10 @@ local server_name = "codeqlls"
 
 local root_pattern = util.root_pattern("qlpack.yml")
 
+-- vim.empty_dict()
 configs[server_name] = {
     default_config = {
+        cmd = {"codeql", "execute", "language-server", "--check-errors", "ON_CHANGE", "-q"};
         filetypes = {'codeql'};
         root_dir = function(fname)
             return root_pattern("qlpack.yml") or util.path.dirname(fname)
@@ -19,10 +21,11 @@ configs[server_name] = {
             }}
         end;
         settings = {
-            search_path = vim.empty_dict()
+            search_path = vim.empty_dict() 
         };
     };
     docs = {
+        package_json = "https://github.com/github/vscode-codeql/blob/master/extensions/ql-vscode/package.json";
         description = [[
 Reference:
 https://help.semmle.com/codeql/codeql-cli.html
@@ -30,17 +33,19 @@ https://help.semmle.com/codeql/codeql-cli.html
 Binaries:
 https://github.com/github/codeql-cli-binaries
         ]];
-        package_json = "https://github.com/github/vscode-codeql/blob/master/extensions/ql-vscode/package.json";
+        default_config = {
+            settings = {
+                search_path = [[list containing all search paths, eg: '~/codeql-home/codeql-repo']];
+            };
+        };
     };
     on_new_config = function(config)
-        if config.settings.search_path ~= nil and config.settings.search_path ~= '' then
+        if type(config.settings.search_path) == 'table' and not vim.tbl_isempty(config.settings.search_path) then
             local search_path = "--search-path="
             for _, path in ipairs(config.settings.search_path) do
                 search_path = search_path..vim.fn.expand(path)..":"
             end
             config.cmd = {"codeql", "execute", "language-server", "--check-errors", "ON_CHANGE", "-q", search_path}
-        else
-            config.cmd = {"codeql", "execute", "language-server", "--check-errors", "ON_CHANGE", "-q"}
         end
     end;
 }

--- a/lua/nvim_lsp/codeqlls.lua
+++ b/lua/nvim_lsp/codeqlls.lua
@@ -21,7 +21,7 @@ configs[server_name] = {
             }}
         end;
         settings = {
-            search_path = vim.empty_dict() 
+            search_path = vim.empty_dict()
         };
     };
     docs = {

--- a/lua/nvim_lsp/codeqlls.lua
+++ b/lua/nvim_lsp/codeqlls.lua
@@ -1,0 +1,40 @@
+local configs = require "nvim_lsp/configs"
+local util = require "nvim_lsp/util"
+local lsp = vim.lsp
+
+local server_name = "codeqlls"
+
+local root_pattern = util.root_pattern("qlpack.yml")
+
+configs[server_name] = {
+    default_config = {
+        filetypes = {'codeql'};
+        root_dir = function(fname)
+            return root_pattern("qlpack.yml") or util.path.dirname(fname)
+        end;
+        log_level = vim.lsp.protocol.MessageType.Warning;
+        before_init = function(initialize_params, config)
+            initialize_params['workspaceFolders'] = {{
+                name = 'workspace',
+                uri = initialize_params['rootUri']
+            }}
+        end;
+        settings = {
+            search_path = vim.empty_dict()
+        };
+    };
+    docs = {
+        description = [[test]]
+    };
+    on_new_config = function(config)
+        if config.settings.search_path ~= nil and config.settings.search_path ~= '' then
+            search_path="--search-path="
+            for _, path in ipairs(config.settings.search_path) do
+                search_path = search_path..vim.fn.expand(path)..":"
+            end
+            config.cmd = {"codeql", "execute", "language-server", "--check-errors", "ON_CHANGE", "-q", search_path}
+        else
+            config.cmd = {"codeql", "execute", "language-server", "--check-errors", "ON_CHANGE", "-q"}
+        end
+    end;
+}

--- a/lua/nvim_lsp/codeqlls.lua
+++ b/lua/nvim_lsp/codeqlls.lua
@@ -5,19 +5,6 @@ local server_name = "codeqlls"
 
 local root_pattern = util.root_pattern("qlpack.yml")
 
-function dump(o)
-   if type(o) == 'table' then
-      local s = '{ '
-      for k,v in pairs(o) do
-         if type(k) ~= 'number' then k = '"'..k..'"' end
-         s = s .. '['..k..'] = ' .. dump(v) .. ','
-      end
-      return s .. '} '
-   else
-      return tostring(o)
-   end
-end
-
 configs[server_name] = {
     default_config = {
         cmd = {"codeql", "execute", "language-server", "--check-errors", "ON_CHANGE", "-q"};
@@ -52,10 +39,6 @@ https://github.com/github/codeql-cli-binaries
         };
     };
     on_new_config = function(config)
-        file = io.open("/tmp/neovim.log", "a")
-        io.output(file)
-        io.write(dump(config.settings))
-        io.close(file)
         if type(config.settings.search_path) == 'table' and not vim.tbl_isempty(config.settings.search_path) then
             local search_path = "--search-path="
             for _, path in ipairs(config.settings.search_path) do

--- a/lua/nvim_lsp/codeqlls.lua
+++ b/lua/nvim_lsp/codeqlls.lua
@@ -5,7 +5,19 @@ local server_name = "codeqlls"
 
 local root_pattern = util.root_pattern("qlpack.yml")
 
--- vim.empty_dict()
+function dump(o)
+   if type(o) == 'table' then
+      local s = '{ '
+      for k,v in pairs(o) do
+         if type(k) ~= 'number' then k = '"'..k..'"' end
+         s = s .. '['..k..'] = ' .. dump(v) .. ','
+      end
+      return s .. '} '
+   else
+      return tostring(o)
+   end
+end
+
 configs[server_name] = {
     default_config = {
         cmd = {"codeql", "execute", "language-server", "--check-errors", "ON_CHANGE", "-q"};
@@ -21,7 +33,7 @@ configs[server_name] = {
             }}
         end;
         settings = {
-            search_path = vim.empty_dict()
+            ["search_path"] = {}
         };
     };
     docs = {
@@ -40,6 +52,10 @@ https://github.com/github/codeql-cli-binaries
         };
     };
     on_new_config = function(config)
+        file = io.open("/tmp/neovim.log", "a")
+        io.output(file)
+        io.write(dump(config.settings))
+        io.close(file)
         if type(config.settings.search_path) == 'table' and not vim.tbl_isempty(config.settings.search_path) then
             local search_path = "--search-path="
             for _, path in ipairs(config.settings.search_path) do

--- a/lua/nvim_lsp/codeqlls.lua
+++ b/lua/nvim_lsp/codeqlls.lua
@@ -1,6 +1,5 @@
 local configs = require "nvim_lsp/configs"
 local util = require "nvim_lsp/util"
-local lsp = vim.lsp
 
 local server_name = "codeqlls"
 
@@ -15,8 +14,8 @@ configs[server_name] = {
         log_level = vim.lsp.protocol.MessageType.Warning;
         before_init = function(initialize_params, config)
             initialize_params['workspaceFolders'] = {{
-                name = 'workspace',
-                uri = initialize_params['rootUri']
+                    name = 'workspace',
+                    uri = initialize_params['rootUri']
             }}
         end;
         settings = {
@@ -35,7 +34,7 @@ https://github.com/github/codeql-cli-binaries
     };
     on_new_config = function(config)
         if config.settings.search_path ~= nil and config.settings.search_path ~= '' then
-            search_path="--search-path="
+            local search_path = "--search-path="
             for _, path in ipairs(config.settings.search_path) do
                 search_path = search_path..vim.fn.expand(path)..":"
             end


### PR DESCRIPTION
Adds support for CodeQL language server

If you want to try, you will need to install codeql-cli and ql queries. Follow instructions [here](https://help.semmle.com/codeql/codeql-cli/procedures/get-started.html#download-the-codeql-cli-zip-package)

you need to pass a `search_path` argument pointing to your QL repo. eg:

``` lua
    require'nvim_lsp'.codeqlls.setup{
        settings = {
            search_path = {'~/codeql-home/codeql-repo'};
        };
    }
```

Create a directory and place a `qlpack.yml` file with:

``` yaml
name: test
version: 0.0.0
libraryPathDependencies: codeql-java
```

In the same directory write a java query `test.ql`, set filetype to `codeql` (I will soon publish a plugin for that) and write your query in it:

```
import java

from Method m
select m.getName()
```

You should get lintering and autocompletion.