### PR TITLE
Change root_dir of pyls to CWD to prevent pyls from traversing HOME directory

### DIFF
--- a/lua/nvim_lsp/pyls.lua
+++ b/lua/nvim_lsp/pyls.lua
@@ -1,11 +1,14 @@
 local configs = require 'nvim_lsp/configs'
+local util = require 'nvim_lsp/util'
 local lsp = vim.lsp
 
 configs.pyls = {
   default_config = {
     cmd = {"pyls"};
     filetypes = {"python"};
-    root_dir = vim.loop.os_homedir;
+    root_dir = function(fname)
+      return util.path.dirname(fname)
+    end;
     log_level = lsp.protocol.MessageType.Warning;
   };
   -- on_new_config = function(new_config) end;


### PR DESCRIPTION
[The doc](https://github.com/neovim/nvim-lsp/blob/be0f71585eb3185b214c84c643e43e9647ef67d1/README.md#pyls) says the root_dir of pyls is "vim's starting directory" but actually it is home directory.

I tried to fix #118 and noticed that rope performs rename on [files under home directory](https://github.com/python-rope/rope/blob/0.16.0/rope/refactor/rename.py#L85-L86). This significantly harms performance.