### PR TITLE
default_config: let user specify default_config yourself.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,19 @@ end
 nvim_lsp.foo_lsp.setup{}
 ```
 
+### Example: orverride default config
+
+If you want to change default configs for all servers, you can override default_config like this.
+
+```lua
+local nvim_lsp = require'nvim_lsp'
+nvim_lsp.util.default_config = vim.tbl_extend(
+  "force",
+  nvim_lsp.util.default_config,
+  { log_level = lsp.protocol.MessageType.Warning.Error }
+)
+```
+
 ### Installing a language server
 
 Configs may provide an `install()` function. Then you can use

--- a/lua/nvim_lsp/configs.lua
+++ b/lua/nvim_lsp/configs.lua
@@ -23,13 +23,7 @@ function configs.__newindex(t, config_name, config_def)
 
   local M = {}
 
-  local default_config = tbl_extend("keep", config_def.default_config, {
-    log_level = lsp.protocol.MessageType.Warning;
-    message_level = lsp.protocol.MessageType.Warning;
-    settings = vim.empty_dict();
-    init_options = vim.empty_dict();
-    callbacks = {};
-  })
+  local default_config = tbl_extend("keep", config_def.default_config, util.default_config)
 
   -- Force this part.
   default_config.name = config_name

--- a/lua/nvim_lsp/util.lua
+++ b/lua/nvim_lsp/util.lua
@@ -7,6 +7,14 @@ local fn = vim.fn
 
 local M = {}
 
+M.default_config = {
+  log_level = lsp.protocol.MessageType.Warning;
+  message_level = lsp.protocol.MessageType.Warning;
+  settings = vim.empty_dict();
+  init_options = vim.empty_dict();
+  callbacks = {};
+}
+
 function M.validate_bufnr(bufnr)
   validate {
     bufnr = { bufnr, 'n' }


### PR DESCRIPTION
If users want to change something like log_level for all servers, changing log_level for all servers is a bit tedious.
So we can make this easier by overriding util.default_config.

I will add documentation if we can agree with this policy.