### PR TITLE
Run hie-wrapper with --lsp

### DIFF
--- a/lua/nvim_lsp/hie.lua
+++ b/lua/nvim_lsp/hie.lua
@@ -3,7 +3,7 @@ local util = require 'nvim_lsp/util'
 
 configs.hie = {
   default_config = {
-    cmd = {"hie-wrapper"};
+    cmd = {"hie-wrapper", "--lsp"};
     filetypes = {"haskell"};
     root_dir = util.root_pattern("stack.yaml", "package.yaml", ".git");
   };


### PR DESCRIPTION
hie-wrapper needs the --lsp option to run as a language server https://github.com/haskell/haskell-ide-engine#using-hie-with-vim-or-neovim