### PR TITLE
[upgrade] acitons/checkout v1 -> v2

### DIFF
--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -14,7 +14,7 @@ jobs:
         sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
         sudo apt update
         sudo apt install dart
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - run: date +%F > todays-date
     - name: Restore cache for today's nightly.
       uses: actions/cache@v1.0.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Setup luacheck
       run: |
         sudo apt update &&


### PR DESCRIPTION
Hello.

I upgrade for actions/checkout@v2
This speeds up CI / CD execution time.
If you need more imformation, please  see this reference below.

## Reference
> https://github.com/actions/checkout#whats-new