### PR TITLE
Add Ada Language Server (als)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ nvim_lsp.SERVER.setup{config}
 The following LSP configs are included. Follow a link to find documentation for
 that config.
 
+- [als](#als)
 - [bashls](#bashls)
 - [ccls](#ccls)
 - [clangd](#clangd)
@@ -253,6 +254,23 @@ that config.
 - [vimls](#vimls)
 - [vuels](#vuels)
 - [yamlls](#yamlls)
+
+## als
+
+https://github.com/adacore/ada_language_server
+
+AdaCore's Ada language server.
+
+Can be installed in Nvim with `:LspInstall als`
+
+```lua
+require'nvim_lsp'.als.setup{}
+
+  Default Values:
+    cmd = { "ada_language_server" } -- On windows: ada_language_server.exe
+    filetypes = { "ada" }
+    root_dir = root_pattern("Makefile", ".git")
+```
 
 ## bashls
 

--- a/lua/nvim_lsp/als.lua
+++ b/lua/nvim_lsp/als.lua
@@ -1,0 +1,92 @@
+local configs = require 'nvim_lsp/configs'
+local util = require 'nvim_lsp/util'
+local server_name = 'als'
+local bin_name = 'ada_language_server'
+
+if vim.fn.has('win32') == 1 then
+  bin_name = 'ada_language_server.exe'
+end
+
+local function make_installer()
+  local install_dir = util.path.join{util.base_install_dir, server_name}
+
+  local url = 'https://dl.bintray.com/reznikmm/ada-language-server/linux-latest.tar.gz'
+  local download_target = util.path.join{install_dir, "als.tar.gz"}
+  local extracted_dir = "linux"
+  local extract_cmd = string.format("tar -xzf '%s' --one-top-level='%s'", download_target, install_dir)
+
+  if vim.fn.has('win32') == 1 then
+    url = 'https://dl.bintray.com/reznikmm/ada-language-server/win32-latest.zip'
+    download_target = util.path.join{install_dir, 'win32-latest.zip'}
+    extracted_dir = 'win32'
+    extract_cmd = string.format("unzip -o '%s' -d '%s'", download_target, install_dir)
+  elseif vim.fn.has('mac') == 1 then
+    url = 'https://dl.bintray.com/reznikmm/ada-language-server/darwin-latest.tar.gz'
+    download_target = util.path.join{install_dir, 'darwin-latest.tar.gz'}
+    extracted_dir = 'darwin'
+    extract_cmd = string.format("tar -xzf '%s' --one-top-level='%s'", download_target, install_dir)
+  end
+
+  local download_cmd = string.format('curl -fLo "%s" --create-dirs "%s"', download_target, url)
+
+  local bin_path = util.path.join{install_dir, extracted_dir, bin_name}
+  local X = {}
+  function X.install()
+    local install_info = X.info()
+    if install_info.is_installed then
+      print(server_name, "is already installed")
+      return
+    end
+    if not (util.has_bins("curl")) then
+      error('Need "curl" to install this.')
+      return
+    end
+    vim.fn.mkdir(install_dir, 'p')
+    vim.fn.system(download_cmd)
+    vim.fn.system(extract_cmd)
+  end
+  function X.info()
+    return {
+      is_installed = util.path.exists(bin_path);
+      install_dir = install_dir;
+      cmd = { bin_path };
+    }
+  end
+  function X.configure(config)
+    local install_info = X.info()
+    if install_info.is_installed then
+      config.cmd = install_info.cmd
+    end
+  end
+  return X
+end
+
+local installer = make_installer()
+
+configs[server_name] = {
+  default_config = {
+    cmd = {bin_name};
+    filetypes = {"ada"};
+    -- *.gpr and *.adc would be nice to have here
+    root_dir = util.root_pattern("Makefile", ".git");
+  };
+  on_new_config = function(config)
+    installer.configure(config)
+  end;
+  docs = {
+    vscode = "AdaCore.ada";
+    package_json = "https://raw.githubusercontent.com/AdaCore/ada_language_server/master/integration/vscode/ada/package.json";
+    description = [[
+https://github.com/AdaCore/ada_language_server
+
+Ada language server. Use `LspInstall als` to install it.
+]];
+    default_config = {
+      root_dir = [[util.root_pattern("Makefile")]];
+    };
+  };
+};
+
+configs[server_name].install = installer.install
+configs[server_name].install_info = installer.info
+-- vim:et ts=2 sw=2


### PR DESCRIPTION
This pull request adds support for the Ada Language Server (https://github.com/AdaCore/ada_language_server). I mostly copied what happened for the scala language server (metals) so if there are issues with this PR, there might also be some with metals :)

One thing that I'm slightly uncomfortable with is the install function, which I only tested on Linux: if it succeeds on OSX, this would be only by accident and I'm quite convinced that it would fail on Windows. Since other installers (pyls and metals) do not seem to try to be multiplatform, I thought this wouldn't be a huge problem.