### PR TITLE
Change root_dir for bashls to pwd

### DIFF
--- a/lua/nvim_lsp/bashls.lua
+++ b/lua/nvim_lsp/bashls.lua
@@ -14,7 +14,7 @@ configs[server_name] = {
   default_config = {
     cmd = {"bash-language-server", "start"};
     filetypes = {"sh"};
-    root_dir = vim.loop.os_homedir;
+    root_dir = util.path.dirname;
   };
   on_new_config = function(new_config)
     local install_info = installer.info()


### PR DESCRIPTION
The bash language server (if provided) will try to initialize all shell files it can find in the `root_dir`. The takes forever and probably isn't great from a security perspective.

> If the rootPath is provided it will initialize all shell files it can find anywhere on that path. This non-exhaustive glob is used to preload the parser.

https://github.com/bash-lsp/bash-language-server/blob/790f5a5203af62755d6cec38ef1620e2b2dc0dcd/server/src/analyser.ts#L33-L35