### PR TITLE
util: add behavior options to tbl_deep_extend function

### DIFF
--- a/lua/nvim_lsp/configs.lua
+++ b/lua/nvim_lsp/configs.lua
@@ -99,16 +99,10 @@ function configs.__newindex(t, config_name, config_def)
     end
 
     local make_config = function(_root_dir)
-      local new_config = vim.tbl_extend("keep", vim.empty_dict(), config)
-      -- Deepcopy anything that is >1 level nested.
-      new_config.settings = vim.deepcopy(new_config.settings)
-      util.tbl_deep_extend(new_config.settings, default_config.settings)
-
-      new_config.init_options = vim.deepcopy(new_config.init_options)
-      util.tbl_deep_extend(new_config.init_options, default_config.init_options)
-
+      local new_config = util.tbl_deep_extend("keep", vim.empty_dict(), config)
+      new_config = util.tbl_deep_extend('keep', new_config, default_config)
       new_config.capabilities = new_config.capabilities or lsp.protocol.make_client_capabilities()
-      util.tbl_deep_extend(new_config.capabilities, {
+      new_config.capabilities = util.tbl_deep_extend('keep', new_config.capabilities, {
         workspace = {
           configuration = true;
         }

--- a/lua/nvim_lsp/elmls.lua
+++ b/lua/nvim_lsp/elmls.lua
@@ -43,7 +43,7 @@ configs[server_name] = {
       else
         new_config.cmd = {install_info.binaries[bin_name]}
       end
-      util.tbl_deep_extend(new_config.init_options, {
+      new_config.init_options = util.tbl_deep_extend('force', new_config.init_options, {
         elmPath = install_info.binaries["elm"];
         elmFormatPath = install_info.binaries["elm-format"];
         elmTestPath = install_info.binaries["elm-test"];


### PR DESCRIPTION
tbl_deep_extend always override extended table properties.
This behavior is not expected. This will fix #155.

ref: https://github.com/neovim/nvim-lsp/pull/98#discussion_r368323527