### PR TITLE
if root_dir is not directry, we don't execute lsp.start_client

### DIFF
--- a/lua/nvim_lsp/configs.lua
+++ b/lua/nvim_lsp/configs.lua
@@ -162,7 +162,6 @@ function configs.__newindex(t, config_name, config_def)
 
     function manager.try_add()
       local root_dir = get_root_dir(api.nvim_buf_get_name(0), api.nvim_get_current_buf())
-      if not root_dir then return end
       local id = manager.add(root_dir)
       if id then
         lsp.buf_attach_client(0, id)

--- a/lua/nvim_lsp/util.lua
+++ b/lua/nvim_lsp/util.lua
@@ -231,6 +231,7 @@ function M.server_per_root_dir_manager(_make_config)
 
   function manager.add(root_dir)
     if not root_dir then return end
+    if not M.path.is_dir(root_dir) then return end
 
     -- Check if we have a client alredy or start and store it.
     local client_id = clients[root_dir]


### PR DESCRIPTION
fix: #161. If the buffer is not actual file like the special buffer for the plugin,
it doesn't have root_dir and we should not execute lsp.start_client for that buffer.