### PR TITLE
Update pyls_ms: 0.5.31

### DIFF
--- a/lua/nvim_lsp/pyls_ms.lua
+++ b/lua/nvim_lsp/pyls_ms.lua
@@ -44,7 +44,7 @@ local function make_installer()
       error('Unable to identify host operating system')
     end
 
-    local url = string.format("https://pvsc.azureedge.net/python-language-server-stable/Python-Language-Server-%s-x64.0.5.30.nupkg", string.lower(system))
+    local url = string.format("https://pvsc.azureedge.net/python-language-server-stable/Python-Language-Server-%s-x64.0.5.31.nupkg", string.lower(system))
     local download_cmd = string.format('curl -fLo %s --create-dirs %s', install_info.install_dir .. "/pyls.nupkg", url)
     local install_cmd = ''
 


### PR DESCRIPTION
## Description

Latest release of the "stable" channel is `0.5.31`.
`pyls_ms.lua` has been updated.

## REF

**osx**

https://pvsc.blob.core.windows.net/python-language-server-stable?restype=container&comp=list&prefix=Python-Language-Server-osx-x64

**win**

https://pvsc.blob.core.windows.net/python-language-server-stable?restype=container&comp=list&prefix=Python-Language-Server-win-x64

**linux**

https://pvsc.blob.core.windows.net/python-language-server-stable?restype=container&comp=list&prefix=Python-Language-Server-linux-x64