### PR TITLE
LspInstall: --no-package-lock --no-save --production

### DIFF
--- a/lua/nvim_lsp/util.lua
+++ b/lua/nvim_lsp/util.lua
@@ -392,7 +392,7 @@ function M.npm_installer(config)
     set -e
     mkdir -p "{{install_dir}}"
     cd "{{install_dir}}"
-    npm install {{packages}} --no-package-lock --no-save --production --silent
+    npm install {{packages}} --no-package-lock --no-save --production
     {{post_install_script}}
     ]]):gsub("{{(%S+)}}", install_params)
     cmd:write(install_script)

--- a/lua/nvim_lsp/util.lua
+++ b/lua/nvim_lsp/util.lua
@@ -392,7 +392,7 @@ function M.npm_installer(config)
     set -e
     mkdir -p "{{install_dir}}"
     cd "{{install_dir}}"
-    npm install {{packages}}
+    npm install {{packages}} --no-package-lock --no-save --production --silent
     {{post_install_script}}
     ]]):gsub("{{(%S+)}}", install_params)
     cmd:write(install_script)


### PR DESCRIPTION
Get rid of missing package.json warnings when installing npm packages.

Also eliminating package-lock.json.