### PR TITLE
Added support for the kotlin-language-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -2258,12 +2258,98 @@ This will result in one executable script (unix) and one \*.bat which are used i
 
 <details><summary>Available settings:</summary>
 
-- **`kotlin-language-server.transport`**: `cli-arg`
+  - **`kotlin.languageServer.enabled`**: `boolean`
 
-  Default: `None`
-  
-  The default option starts the server via stdio, which is our desired transport
-  protocol.
+      default: `true`
+
+      description: `[Recommended] Specifies whether the language server should be used. When enabled the extension will provide code completions and linting, otherwise just syntax highlighting. Might require a reload to apply.`
+
+- **`kotlin.languageServer.path`**: `string`
+
+      default: `""`
+
+      description: `Optionally a custom path to the language server executable.`
+
+- **`kotlin.languageServer.transport`**: `string`
+
+      default: `stdio`
+
+      enum: [`stdio`, `tcp`],
+      description: `The transport layer beneath the language server protocol. Note that the extension will launch the server even if a TCP socket is used.`,
+
+- **`kotlin.languageServer.port`**: `integer`
+
+      default: ``
+
+      description: `The port to which the client will attempt to connect to. A random port is used if zero. Only used if the transport layer is TCP.`,
+
+- **`kotlin.trace.server`**: `string`
+
+      default: `"off"`
+
+      enum: [
+          `off`,
+      `messages`,
+      `verbose`
+      ],
+      description: `Traces the communication between VSCode and the Kotlin language server.`,
+      scope: `window`
+
+- **`kotlin.compiler.jvm.target`**: `string`
+      
+      default: `"default"`
+
+      description: `Specifies the JVM target, e.g. \`1.6\` or \`1.8\``
+
+- **`kotlin.linting.debounceTime`**: `integer`
+
+      default: `250`
+
+      description: `[DEBUG] Specifies the debounce time limit. Lower to increase responsiveness at the cost of possibile stability issues.`
+
+- **`kotlin.completion.snippets.enabled`**: `boolean`
+
+      default: `true`
+
+      description: `Specifies whether code completion should provide snippets (true) or plain-text items (false).`
+
+- **`kotlin.debugAdapter.enabled`**: `boolean`
+
+      default: `true`
+
+      description: `[Recommended] Specifies whether the debug adapter should be used. When enabled a debugger for Kotlin will be available.`
+
+- **`kotlin.debugAdapter.path`**: `string`
+
+      default: `""`
+
+      description: `Optionally a custom path to the debug adapter executable.`
+
+- **`kotlin.debounceTime`**: `integer`
+
+      default: `250`
+
+      description: `[DEPRECATED] Specifies the debounce time limit. Lower to increase responsiveness at the cost of possibile stability issues.`,
+      deprecationMessage: `Use 'kotlin.linting.debounceTime' instead`
+
+- **`kotlin.externalSources.useKlsScheme`**: `boolean`
+
+      default: `true`
+
+      description: `[Recommended] Specifies whether URIs inside JARs should be represented using the 'kls'-scheme.`
+
+- **`kotlin.externalSources.autoConvertToKotlin`**: `boolean`
+
+      default: `true`
+
+      description: `Specifies whether decompiled/external classes should be auto-converted to Kotlin.`
+
+- **`kotlin.snippetsEnabled`**: `boolean`
+
+      default: `true`
+
+      description: `[DEPRECATED] Specifies whether code completion should provide snippets (true) or plain-text items (false).`,
+      deprecationMessage: `Use 'kotlin.completion.snippets.enabled'`
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -2258,7 +2258,7 @@ This will result in one executable script (unix) and one \*.bat which are used i
 
 <details><summary>Available settings:</summary>
 
-  - **`kotlin.languageServer.enabled`**: `boolean`
+- **`kotlin.languageServer.enabled`**: `boolean`
 
       default: `true`
 

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ that config.
 - [intelephense](#intelephense)
 - [jsonls](#jsonls)
 - [julials](#julials)
+- [kotlin_language_server](#kotlin_language_server)
 - [leanls](#leanls)
 - [metals](#metals)
 - [nimls](#nimls)
@@ -2230,6 +2231,50 @@ require'nvim_lsp'.julials.setup{}
     cmd = { "julia", "--project", "--startup-file=no", "--history-file=no", "-e", "        using LanguageServer;\n        using Pkg;\n        server = LanguageServer.LanguageServerInstance(stdin, stdout, false, dirname(Pkg.Types.Context().env.project_file));\n        server.runlinter = true; run(server);\n        " }
     filetypes = { "julia" }
     root_dir = <function 1>
+```
+
+## kotlin_language_server
+
+https://github.com/fwcd/kotlin-language-server
+
+Kotlin Language Server.
+Requirements:
+  * java 8+ on path
+  * (optional) kotlinc on path for gradle-less projects
+  * `kotlin`-filetype support for vim.
+
+Simply follow the build instructions from the source, summarized:
+
+```bash
+git clone && cd
+./gradlew :server:installDist
+```
+
+Gradle will download itself and all dependencies. 
+Output to start the server is a script (unix or \*.bat), located at:
+`/path/to/git/of/kotlin-language-server/server/build/install/server/bin/`
+
+This will result in one executable script (unix) and one \*.bat which are used in the configuration below.
+
+<details><summary>Available settings:</summary>
+
+- **`kotlin-language-server.transport`**: `cli-arg`
+
+  Default: `None`
+  
+  The default option starts the server via stdio, which is our desired transport
+  protocol.
+
+</details>
+
+configuration:
+
+```lua
+require 'nvim_lsp'.kotlin_language_server.setup {
+  -- Default Values:
+	cmd = { "/path/to/git/of/kotlin-language-server/" .. "server/build/install/server/bin/kotlin-language-server" }; -- startup script
+};
+
 ```
 
 ## leanls

--- a/lua/nvim_lsp/kotlin_language_server.lua
+++ b/lua/nvim_lsp/kotlin_language_server.lua
@@ -6,7 +6,6 @@
 --- 	https://github.com/udalov/kotlin-vim (recommended)
 --- 	Note that there is no LICENSE specified yet.
 
-local vim = vim	-- from global table
 local util = require 'nvim_lsp/util'
 local configs = require 'nvim_lsp/configs'
 

--- a/lua/nvim_lsp/kotlin_language_server.lua
+++ b/lua/nvim_lsp/kotlin_language_server.lua
@@ -1,0 +1,58 @@
+--- default config for gradle-projects of the
+--- kotlin-language-server: https://github.com/fwcd/kotlin-language-server
+---
+--- This server requires vim to be aware of the kotlin-filetype.
+--- You could refer for this capability to:
+--- 	https://github.com/udalov/kotlin-vim (recommended)
+--- 	Note that there is no LICENSE specified yet.
+
+local vim = vim	-- from global table
+local util = require 'nvim_lsp/util'
+local configs = require 'nvim_lsp/configs'
+--- kotlin-language-server supports multiple types of projects.
+--- The default works with single- and multi-module gradle projects.
+local function get_project_root()
+  return util.root_pattern("settings.gradle")
+end
+
+configs.kotlin_language_server = {
+  default_config = util.utf8_config {
+	filetypes = { "kotlin" };
+	root_dir = get_project_root();
+	log_level = vim.lsp.protocol.MessageType.Warning;
+  };
+  docs = {
+	vscode = "0.5.2";
+	description = [[
+A kotlin language server which was developed for internal usage and
+released afterwards. Maintaining is not done by the original author,
+but by fwcd.
+
+It is builded via gradle and developed on github.
+Source and additional description:
+	https://github.com/fwcd/kotlin-language-server
+]];
+	default_config = {
+	  root_dir = [[root_pattern("settings.gradle")]];
+	  capabilities = [[
+	  smart code completion,
+	  diagnostics,
+	  hover,
+	  document symbols,
+	  definition lookup,
+	  method signature help,
+	  dependency resolution,
+	  additional plugins from: https://github.com/fwcd
+
+		Snipped of License (refer to source for full License):
+
+		The MIT License (MIT)
+
+		Copyright (c) 2016 George Fraser
+		Copyright (c) 2018 fwcd
+
+	  ]];
+	};
+  };
+}
+

--- a/lua/nvim_lsp/kotlin_language_server.lua
+++ b/lua/nvim_lsp/kotlin_language_server.lua
@@ -10,7 +10,7 @@ local util = require 'nvim_lsp/util'
 local configs = require 'nvim_lsp/configs'
 
 configs.kotlin_language_server = {
-  default_config = util.utf8_config {
+  default_config = {
     filetypes = { "kotlin" };
     root_dir = util.root_pattern("settings.gradle");
   };

--- a/lua/nvim_lsp/kotlin_language_server.lua
+++ b/lua/nvim_lsp/kotlin_language_server.lua
@@ -9,50 +9,45 @@
 local vim = vim	-- from global table
 local util = require 'nvim_lsp/util'
 local configs = require 'nvim_lsp/configs'
---- kotlin-language-server supports multiple types of projects.
---- The default works with single- and multi-module gradle projects.
-local function get_project_root()
-  return util.root_pattern("settings.gradle")
-end
 
 configs.kotlin_language_server = {
   default_config = util.utf8_config {
-	filetypes = { "kotlin" };
-	root_dir = get_project_root();
-	log_level = vim.lsp.protocol.MessageType.Warning;
+    filetypes = { "kotlin" };
+    root_dir = util.root_pattern("settings.gradle");
   };
   docs = {
-	vscode = "0.5.2";
-	description = [[
-A kotlin language server which was developed for internal usage and
-released afterwards. Maintaining is not done by the original author,
-but by fwcd.
+    package_json = "https://raw.githubusercontent.com/fwcd/vscode-kotlin/master/package.json";
+    description = [[
+    A kotlin language server which was developed for internal usage and
+    released afterwards. Maintaining is not done by the original author,
+    but by fwcd.
 
-It is builded via gradle and developed on github.
-Source and additional description:
-	https://github.com/fwcd/kotlin-language-server
-]];
-	default_config = {
-	  root_dir = [[root_pattern("settings.gradle")]];
-	  capabilities = [[
-	  smart code completion,
-	  diagnostics,
-	  hover,
-	  document symbols,
-	  definition lookup,
-	  method signature help,
-	  dependency resolution,
-	  additional plugins from: https://github.com/fwcd
+    It is builded via gradle and developed on github.
+    Source and additional description:
+    https://github.com/fwcd/kotlin-language-server
+    ]];
+    default_config = {
+      root_dir = [[root_pattern("settings.gradle")]];
+      capabilities = [[
+      smart code completion,
+      diagnostics,
+      hover,
+      document symbols,
+      definition lookup,
+      method signature help,
+      dependency resolution,
+      additional plugins from: https://github.com/fwcd
 
-		Snipped of License (refer to source for full License):
+      Snipped of License (refer to source for full License):
 
-		The MIT License (MIT)
+      The MIT License (MIT)
 
-		Copyright (c) 2016 George Fraser
-		Copyright (c) 2018 fwcd
+      Copyright (c) 2016 George Fraser
+      Copyright (c) 2018 fwcd
 
-	  ]];
-	};
+      ]];
+    };
   };
 }
 
+-- vim:et ts=2 sw=2


### PR DESCRIPTION
This PR adds support for the kotlin-language-server found at fwcd's [repository](https://github.com/fwcd/kotlin-language-server).

> Please provide guidance about further steps I should consider to make this contribution pass.

// edit:
Unfortunately I did not manage to rebase an fix for recover the lint test of the CI-pipe (trailing whitespaces). Should I rebase (squash all of my commits) from the previous commit (#d16b49e)? I picked #5e5c8b5 of my branch. Result is displayed below..