### PR TITLE
Allow empty section string for configuration request

### DIFF
--- a/lua/nvim_lsp/configs.lua
+++ b/lua/nvim_lsp/configs.lua
@@ -60,6 +60,10 @@ function configs.__newindex(t, config_name, config_def)
       for _, item in ipairs(params.items) do
         if item.section then
           local value = util.lookup_section(config.settings, item.section) or vim.NIL
+          -- For empty sections with no explicit '' key, return settings as is
+          if value == vim.NIL and item.section == '' then
+            value = config.settings or vim.NIL
+          end
           table.insert(result, value)
         end
       end


### PR DESCRIPTION
microsoft/vscode-eslint requests configuration with a section of ''.
This change returns the expected settings in that case.

https://github.com/microsoft/vscode-eslint/blob/be30e933c56ea6e8e579808d5f7c7b205c8e16cc/server/src/eslintServer.ts#L668