### PR TITLE
Remove unnecessary init_options for Metals.

### DIFF
--- a/lua/nvim_lsp/metals.lua
+++ b/lua/nvim_lsp/metals.lua
@@ -67,21 +67,9 @@ configs[server_name] = {
     message_level = vim.lsp.protocol.MessageType.Log;
     init_options = {
         statusBarProvider = "show-message",
-        didFocusProvider = false,
-        slowTaskProvider = false,
-        inputBoxProvider = false,
-        quickPickProvider = false,
-        executeClientCommandProvider = false,
-        doctorProvider = "html",
-        isExitOnShutdown = false,
         isHttpEnabled = true,
         compilerOptions = {
-          isCompletionItemDetailEnabled = true,
-          isCompletionItemDocumentationEnabled = true,
-          isHoverDocumentationEnabled = true,
-          snippetAutoIndent = false,
-          isSignatureHelpDocumentationEnabled = true,
-          isCompletionItemResolve = true
+          snippetAutoIndent = false
         }
       };
   };


### PR DESCRIPTION
As of the 0.9.0 release of Metals, a bug was fixed where previously all
of the `InitializationOptions` needed to be specified if you set any in
order to not have a null pointer exception. This is fixed now so all of
the default have been removed, and only the necessary ones remain.