### PR TITLE
Fix: Check that vim.fn.has returns 1 in tsserver module

### DIFF
--- a/lua/nvim_lsp/tsserver.lua
+++ b/lua/nvim_lsp/tsserver.lua
@@ -3,7 +3,7 @@ local util = require 'nvim_lsp/util'
 
 local server_name = "tsserver"
 local bin_name = "typescript-language-server"
-if vim.fn.has('win32') then
+if vim.fn.has('win32') == 1 then
   bin_name = bin_name..".cmd"
 end
 


### PR DESCRIPTION
After this PR https://github.com/neovim/nvim-lsp/pull/222 was merged I started to get this error when opening nvim:

```
Error detected while processing FileType Autocommands for "javascript":
E5108: Error executing lua ...ovim/HEAD-d13c164/share/nvim/runtime/lua/vim/lsp/rpc.lua:208: The given command "typescript-language-server.cmd" is not execut
able.
```

The problem is that `vim.fn.has` returns `0` or `1`, and those both values are truthy values in Lua. The module needs to explicitly check for `1` in order to pass the `if` condition.

You can check how this works in Lua by running this in nvim:

```
:lua << EOF
if 0 then
  print('oh no')
end
EOF
```

You should see immediatly the `oh no` message.