### PR TITLE
Add .terraform/ as a root dir for terraformls

### DIFF
--- a/README.md
+++ b/README.md
@@ -4239,7 +4239,7 @@ require'nvim_lsp'.terraformls.setup{}
   Default Values:
     cmd = { "terraform-lsp" }
     filetypes = { "terraform" }
-    root_dir = root_pattern(".git")
+    root_dir = root_pattern(".terraform", ".git")
 ```
 
 ## texlab

--- a/lua/nvim_lsp/terraformls.lua
+++ b/lua/nvim_lsp/terraformls.lua
@@ -5,7 +5,7 @@ configs.terraformls = {
   default_config = {
     cmd = {"terraform-lsp"};
     filetypes = {"terraform"};
-    root_dir = util.root_pattern(".git");
+    root_dir = util.root_pattern(".terraform", ".git");
   };
   docs = {
     vscode = "mauve.terraform";
@@ -16,7 +16,7 @@ Terraform language server
 You can use [released binary](https://github.com/juliosueiras/terraform-lsp/releases) or [build](https://github.com/juliosueiras/terraform-lsp#building) your own.
 ]];
     default_config = {
-      root_dir = [[root_pattern(".git")]];
+      root_dir = [[root_pattern(".terraform", ".git")]];
     };
   };
 }


### PR DESCRIPTION
`terraform init` creates .terraform/ and is a better indicator of the root than .git/ in many cases