### PR TITLE
config: remove unnecessary code comennts and utf8 option

### DIFF
--- a/lua/nvim_lsp/bashls.lua
+++ b/lua/nvim_lsp/bashls.lua
@@ -27,7 +27,6 @@ configs[server_name] = {
       end
     end
   end;
-  -- on_attach = function(client, bufnr) end;
   docs = {
     description = [[
 https://github.com/mads-hartmann/bash-language-server

--- a/lua/nvim_lsp/ccls.lua
+++ b/lua/nvim_lsp/ccls.lua
@@ -2,14 +2,11 @@ local configs = require 'nvim_lsp/configs'
 local util = require 'nvim_lsp/util'
 
 configs.ccls = {
-  default_config = util.utf8_config {
+  default_config = {
     cmd = {"ccls"};
     filetypes = {"c", "cpp", "objc", "objcpp"};
     root_dir = util.root_pattern("compile_commands.json", "compile_flags.txt", ".git");
   };
-  -- commands = {};
-  -- on_new_config = function(new_config) end;
-  -- on_attach = function(client, bufnr) end;
   docs = {
     vscode = "ccls-project.ccls";
     description = [[
@@ -20,8 +17,6 @@ as compile_commands.json or, for simpler projects, a compile_flags.txt.
 ]];
     default_config = {
       root_dir = [[root_pattern("compile_commands.json", "compile_flags.txt", ".git")]];
-      on_init = [[function to handle changing offsetEncoding]];
-      capabilities = [[default capabilities, with offsetEncoding utf-8]];
     };
   };
 }

--- a/lua/nvim_lsp/clangd.lua
+++ b/lua/nvim_lsp/clangd.lua
@@ -12,9 +12,6 @@ configs.clangd = {
       return root_pattern(filename) or util.path.dirname(filename)
     end;
   };
-  -- commands = {};
-  -- on_new_config = function(new_config) end;
-  -- on_attach = function(client, bufnr) end;
   docs = {
     description = [[
 https://clang.llvm.org/extra/clangd/Installation.html

--- a/lua/nvim_lsp/cssls.lua
+++ b/lua/nvim_lsp/cssls.lua
@@ -13,7 +13,7 @@ local installer = util.npm_installer {
 local root_pattern = util.root_pattern("package.json")
 
 configs[server_name] = {
-  default_config = util.utf8_config {
+  default_config = {
     cmd = {bin_name, "--stdio"};
     filetypes = {"css", "scss", "less"};
     root_dir = function(fname)
@@ -47,8 +47,6 @@ npm install -g vscode-css-languageserver-bin
 ]];
     default_config = {
       root_dir = [[root_pattern("package.json")]];
-      on_init = [[function to handle changing offsetEncoding]];
-      capabilities = [[default capabilities, with offsetEncoding utf-8]];
     };
   };
 }

--- a/lua/nvim_lsp/elmls.lua
+++ b/lua/nvim_lsp/elmls.lua
@@ -17,7 +17,7 @@ default_capabilities.offsetEncoding = {"utf-8", "utf-16"}
 local elm_root_pattern = util.root_pattern("elm.json")
 
 configs[server_name] = {
-  default_config = util.utf8_config {
+  default_config = {
     cmd = {bin_name};
     -- TODO(ashkan) if we comment this out, it will allow elmls to operate on elm.json. It seems like it could do that, but no other editor allows it right now.
     filetypes = {"elm"};
@@ -62,8 +62,6 @@ npm install -g elm elm-test elm-format @elm-tooling/elm-language-server
 ]];
     default_config = {
       root_dir = [[root_pattern("elm.json")]];
-      on_init = [[function to handle changing offsetEncoding]];
-      capabilities = [[default capabilities, with offsetEncoding utf-8]];
     };
   };
 }

--- a/lua/nvim_lsp/fortls.lua
+++ b/lua/nvim_lsp/fortls.lua
@@ -10,8 +10,6 @@ configs.fortls = {
       nthreads = 1,
     };
   };
-  -- on_new_config = function(new_config) end;
-  -- on_attach = function(client, bufnr) end;
   docs = {
     vscode = 'hansec.fortran-ls';
     description = [[
@@ -24,5 +22,4 @@ Fortran Language Server for the Language Server Protocol
     };
   };
 };
-
 -- vim:et ts=2 sw=2

--- a/lua/nvim_lsp/intelephense.lua
+++ b/lua/nvim_lsp/intelephense.lua
@@ -11,7 +11,7 @@ local installer = util.npm_installer {
 }
 
 configs[server_name] = {
-  default_config = util.utf8_config {
+  default_config = {
     cmd = {bin_name, "--stdio"};
     filetypes = {"php"};
     root_dir = function (pattern)
@@ -44,8 +44,6 @@ npm install -g intelephense
 ]];
     default_config = {
       root_dir = [[root_pattern("composer.json", ".git")]];
-      on_init = [[function to handle changing offsetEncoding]];
-      capabilities = [[default capabilities, with offsetEncoding utf-8]];
       init_options = [[{
         storagePath = Optional absolute path to storage dir. Defaults to os.tmpdir().
         globalStoragePath = Optional absolute path to a global storage dir. Defaults to os.homedir().

--- a/lua/nvim_lsp/leanls.lua
+++ b/lua/nvim_lsp/leanls.lua
@@ -7,8 +7,6 @@ configs.leanls = {
     filetypes = {"lean"};
     root_dir = util.root_pattern(".git");
   };
-  -- on_new_config = function(new_config) end;
-  -- on_attach = function(client, bufnr) end;
   docs = {
     vscode = "jroesch.lean";
     description = [[

--- a/lua/nvim_lsp/pyls.lua
+++ b/lua/nvim_lsp/pyls.lua
@@ -9,8 +9,6 @@ configs.pyls = {
       return util.path.dirname(fname)
     end;
   };
-  -- on_new_config = function(new_config) end;
-  -- on_attach = function(client, bufnr) end;
   docs = {
     package_json = "https://raw.githubusercontent.com/palantir/python-language-server/develop/vscode-client/package.json";
     description = [[
@@ -23,5 +21,4 @@ https://github.com/palantir/python-language-server
     };
   };
 };
-
 -- vim:et ts=2 sw=2

--- a/lua/nvim_lsp/pyls_ms.lua
+++ b/lua/nvim_lsp/pyls_ms.lua
@@ -107,21 +107,18 @@ configs[name] = {
       installer.configure(config)
     end;
     init_options = {
-      interpreter =
-                {
-                    properties=
-                    {
-                        InterpreterPath=vim.fn.exepath("python");
-                        Version=get_python_version();
-                    };
-                };
-      displayOptions= {};
-      analysisUpdates=true;
-      asyncStartup=true;
+      interpreter = {
+        properties =
+        {
+          InterpreterPath = vim.fn.exepath("python");
+          Version = get_python_version();
+        };
+      };
+      displayOptions = {};
+      analysisUpdates = true;
+      asyncStartup = true;
     };
   };
-  -- on_new_config = function(new_config) end;
-  -- on_attach = function(client, bufnr) end;
   docs = {
     description = [[
 https://github.com/Microsoft/python-language-server
@@ -153,3 +150,4 @@ This server accepts configuration via the `settings` key.
 
 configs[name].install = installer.install
 configs[name].install_info = installer.info
+-- vim:et ts=2 sw=2

--- a/lua/nvim_lsp/sourcekit.lua
+++ b/lua/nvim_lsp/sourcekit.lua
@@ -7,8 +7,6 @@ configs.sourcekit = {
     filetypes = {"swift"};
     root_dir = util.root_pattern("Package.swift", ".git")
   };
-  -- on_new_config = function(new_config) end;
-  -- on_attach = function(client, bufnr) end;
   docs = {
     package_json = "https://raw.githubusercontent.com/apple/sourcekit-lsp/master/Editors/vscode/package.json";
     description = [[
@@ -21,5 +19,4 @@ Language server for Swift and C/C++/Objective-C.
     };
   };
 };
-
 -- vim:et ts=2 sw=2

--- a/lua/nvim_lsp/texlab.lua
+++ b/lua/nvim_lsp/texlab.lua
@@ -66,11 +66,7 @@ configs.texlab = {
       end;
       description = "Build the current buffer";
     };
-    -- TexlabCancelAllBuilds = {
-    -- };
   };
-  -- on_new_config = function(new_config) end;
-  -- on_attach = function(client, bufnr) end;
   docs = {
     description = [[
 https://texlab.netlify.com/

--- a/lua/nvim_lsp/tsserver.lua
+++ b/lua/nvim_lsp/tsserver.lua
@@ -14,7 +14,7 @@ local installer = util.npm_installer {
 }
 
 configs[server_name] = {
-  default_config = util.utf8_config {
+  default_config = {
     cmd = {bin_name, "--stdio"};
     filetypes = {"javascript", "javascriptreact", "javascript.jsx", "typescript", "typescriptreact", "typescript.tsx"};
     root_dir = util.root_pattern("package.json", "tsconfig.json", ".git");
@@ -41,8 +41,6 @@ npm install -g typescript-language-server
 ]];
     default_config = {
       root_dir = [[root_pattern("package.json", "tsconfig.json", ".git")]];
-      on_init = [[function to handle changing offsetEncoding]];
-      capabilities = [[default capabilities, with offsetEncoding utf-8]];
     };
   };
 }


### PR DESCRIPTION
Remove meaningless code comments because they are increased by copy and paste.
Currently, utf8 options are only supported by clangd, so remove them from unnecessary ones.