### PR TITLE
Add configuration for elixir-ls

### DIFF
--- a/lua/nvim_lsp/elixirls.lua
+++ b/lua/nvim_lsp/elixirls.lua
@@ -3,21 +3,21 @@ local util = require 'nvim_lsp/util'
 
 local server_name = "elixirls"
 local bin_name = "elixir-ls"
-local bin
+local cmd = "language_server"
+
+if vim.fn.has('mac') == 1 or vim.fn.has('unix') == 1 then
+    cmd = cmd..".sh"
+elseif vim.fn.has('win32') == 1  or vim.fn.has('win64') == 1 then
+    cmd = cmd..".bat"
+else
+    error("System is not supported, try to install manually.")
+    return
+end
 
 local function make_installer()
     local P = util.path.join
     local install_dir = P{util.base_install_dir, server_name}
-    local git_dir = P{install_dir, bin_name}
-
-    if vim.fn.has('mac') == 1 or vim.fn.has('unix') == 1 then
-        bin = P{git_dir, "release", "language_server.sh"}
-    elseif vim.fn.has('win32') == 1  or vim.fn.has('win64') == 1 then
-        bin = P{git_dir, "release", "language_server.bat"}
-    else
-        error("System is not supported, try to install manually.")
-        return
-    end
+	local cmd_path = P{install_dir, bin_name, "release", cmd}
 
     local X = {}
     function X.install()
@@ -51,9 +51,9 @@ local function make_installer()
 
     function X.info()
         return {
-            is_installed = util.path.exists(bin);
+            is_installed = util.path.exists(cmd_path);
             install_dir = install_dir;
-            cmd = { bin };
+            cmd = { cmd_path };
         }
     end
 
@@ -70,7 +70,7 @@ local installer = make_installer()
 
 configs[server_name] = {
   default_config = {
-    -- cmd = {bin};
+    cmd = { cmd };
     filetypes = {"elixir", "eelixir"};
     root_dir = function(fname)
         return util.root_pattern("mix.exs", ".git")(fname) or vim.loop.os_homedir()

--- a/lua/nvim_lsp/elixirls.lua
+++ b/lua/nvim_lsp/elixirls.lua
@@ -38,7 +38,7 @@ local function make_installer()
             # clone project
             git clone https://github.com/elixir-lsp/elixir-ls
             cd elixir-ls
-            
+
             # fetch dependencies and compile
             mix deps.get && mix compile
 

--- a/lua/nvim_lsp/elixirls.lua
+++ b/lua/nvim_lsp/elixirls.lua
@@ -70,7 +70,7 @@ local installer = make_installer()
 
 configs[server_name] = {
   default_config = {
-    cmd = {bin};
+    -- cmd = {bin};
     filetypes = {"elixir", "eelixir"};
     root_dir = function(fname)
         return util.root_pattern("mix.exs", ".git")(fname) or vim.loop.os_homedir()
@@ -82,25 +82,23 @@ configs[server_name] = {
     docs = {
         package_json = "https://raw.githubusercontent.com/JakeBecker/vscode-elixir-ls/master/package.json";
         description = [[
-        https://github.com/elixir-lsp/elixir-ls
+https://github.com/elixir-lsp/elixir-ls
 
-        Elixir language server. This LSP does not provide a language server by default, but it makes an attempt
-        at installing it by cloning the git repo and compiling it using elixir's build tool Mix. This is also
-        the reason for not including the `cmd` option by default. This can be set by using the following format:
-        ```lua
-        require'nvim_lsp'.elixirLS.setup{
-            -- Unix
-            cmd = {"path/to/language_server.sh"};
-            -- Windows
-            cmd = {"path/to/language_server.bat"};
-            ...
-        }
-        ```
+`elixir-ls` can be installed via `:LspInstall elixirls` or by yourself by following the instructions [here](https://github.com/elixir-lsp/elixir-ls#building-and-running).
 
-        Use `LspInstall elixirls` to install it.
+This language server does not provide a global binary, but must be installed manually. The command `:LspInstaller elixirls` makes an attempt at installing the binary by
+Fetching the elixir-ls repository from GitHub, compiling it and then installing it.
 
-        If you want to install it manually, following the instructions [here](https://github.com/elixir-lsp/elixir-ls#building-and-running)
-        ]];
+```lua
+require'nvim_lsp'.elixirLS.setup{
+    -- Unix
+    cmd = { "path/to/language_server.sh" };
+    -- Windows
+    cmd = { "path/to/language_server.bat" };
+    ...
+}
+```
+]];
             default_config = {
                 root_dir = [[root_pattern("mix.exs", ".git") or vim.loop.os_homedir()]];
             };

--- a/lua/nvim_lsp/elixirls.lua
+++ b/lua/nvim_lsp/elixirls.lua
@@ -1,0 +1,113 @@
+local configs = require 'nvim_lsp/configs'
+local util = require 'nvim_lsp/util'
+
+local server_name = "elixirls"
+local bin_name = "elixir-ls"
+local bin
+
+local function make_installer()
+    local P = util.path.join
+    local install_dir = P{util.base_install_dir, server_name}
+    local git_dir = P{install_dir, bin_name}
+
+    if vim.fn.has('mac') == 1 or vim.fn.has('unix') == 1 then
+        bin = P{git_dir, "release", "language_server.sh"}
+    elseif vim.fn.has('win32') == 1  or vim.fn.has('win64') == 1 then
+        bin = P{git_dir, "release", "language_server.bat"}
+    else
+        error("System is not supported, try to install manually.")
+        return
+    end
+
+    local X = {}
+    function X.install()
+        local install_info = X.info()
+        if install_info.is_installed then
+            print(server_name, "is already installed.")
+            return
+        end
+
+        if not (util.has_bins("elixir") and util.has_bins("erl")) then
+            error("Need elixir and erl to install this")
+            return
+        end
+
+        local script = [=[
+            set -e
+            bin_name=]=] .. bin_name .. '\n' ..  [=[
+
+            # clone project
+            git clone https://github.com/elixir-lsp/$bin_name
+            cd $bin_name
+            
+            # fetch dependencies and compile
+            mix deps.get && mix compile
+
+            # install executable
+            mix elixir_ls.release -o release
+        ]=]
+        vim.fn.mkdir(install_info.install_dir, "p")
+        util.sh(script, install_info.install_dir)
+    end
+
+    function X.info()
+        return {
+            is_installed = util.path.exists(bin);
+            install_dir = install_dir;
+            cmd = { bin };
+        }
+    end
+
+    function X.configure(config)
+        local install_info = X.info()
+        if install_info.is_installed then
+            config.cmd = install_info.cmd
+        end
+    end
+    return X
+end
+
+local installer = make_installer()
+
+configs[server_name] = {
+  default_config = {
+    cmd = {bin};
+    filetypes = {"elixir", "eelixir"};
+    root_dir = function(fname)
+        return util.root_pattern("mix.exs", ".git")(fname) or vim.loop.os_homedir()
+    end;
+    };
+    on_new_config = function(config)
+        installer.configure(config)
+    end;
+    docs = {
+        package_json = "https://raw.githubusercontent.com/JakeBecker/vscode-elixir-ls/master/package.json";
+        description = [[
+        https://github.com/elixir-lsp/elixir-ls
+
+        Elixir language server. This LSP does not provide a language server by default, but it makes an attempt
+        at installing it by cloning the git repo and compiling it using elixir's build tool Mix. This is also
+        the reason for not including the `cmd` option by default. This can be set by using the following format:
+        ```lua
+        require'nvim_lsp'.elixirLS.setup{
+            -- Unix
+            cmd = {"path/to/language_server.sh"};
+            -- Windows
+            cmd = {"path/to/language_server.bat"};
+            ...
+        }
+        ```
+
+        Use `LspInstall elixirls` to install it.
+
+        If you want to install it manually, following the instructions [here](https://github.com/elixir-lsp/elixir-ls#building-and-running)
+        ]];
+            default_config = {
+                root_dir = [[root_pattern("mix.exs", ".git") or vim.loop.os_homedir()]];
+            };
+    };
+}
+
+configs[server_name].install = installer.install
+configs[server_name].install_info = installer.info
+-- vim:et ts=2 sw=2

--- a/lua/nvim_lsp/elixirls.lua
+++ b/lua/nvim_lsp/elixirls.lua
@@ -34,11 +34,10 @@ local function make_installer()
 
         local script = [=[
             set -e
-            bin_name=]=] .. bin_name .. '\n' ..  [=[
 
             # clone project
-            git clone https://github.com/elixir-lsp/$bin_name
-            cd $bin_name
+            git clone https://github.com/elixir-lsp/elixir-ls
+            cd elixir-ls
             
             # fetch dependencies and compile
             mix deps.get && mix compile


### PR DESCRIPTION
Add support for Elixir language server.

If you run `:LspInstaller elixirls` it clones the elixir-lsp/elixir-ls repo and builds the binary. It is only tested on Ubuntu 19.10, so should probably be tested on other environments. I'm not completely sure if the Windows install works. 

There is an error when trying to open an elixir-file if the LSP's cmd isn't configured correctly, I think that is caused by the autocmd created by M.setup in configs.lua.