### PR TITLE
flow: use npx instead of expecting a npm script

### DIFF
--- a/lua/nvim_lsp/flow.lua
+++ b/lua/nvim_lsp/flow.lua
@@ -3,7 +3,7 @@ local util = require 'nvim_lsp/util'
 
 configs.flow = {
   default_config = {
-    cmd = {"npm", "run", "flow","lsp"};
+    cmd = {"npx", "flow","lsp"};
     filetypes = {"javascript", "javascriptreact", "javascript.jsx"};
     root_dir = util.root_pattern(".flowconfig");
   };
@@ -19,7 +19,7 @@ https://flow.org/en/docs/install/
 See below for lsp command options.
 
 ```sh
-npm run flow lsp -- --help
+npx flow lsp --help
 ```
     ]];
     default_config = {

--- a/lua/nvim_lsp/flow.lua
+++ b/lua/nvim_lsp/flow.lua
@@ -3,7 +3,7 @@ local util = require 'nvim_lsp/util'
 
 configs.flow = {
   default_config = {
-    cmd = {"npx", "flow","lsp"};
+    cmd = {"npx", "--no-install", "flow","lsp"};
     filetypes = {"javascript", "javascriptreact", "javascript.jsx"};
     root_dir = util.root_pattern(".flowconfig");
   };


### PR DESCRIPTION
Hey!

I noticed the config for the flow language server expects a specific npm script: `npm run flow lsp`. Wouldn't it be better to not rely on this npm script and use npx instead: `npx flow lsp`. This would also mean that flow will be installed if not present in the current project (see https://github.com/npm/npx#description).

Tbh, I'm not familiar with flow and how projects use it. I'm just looking at one project without that npm script and tested it with npx. If there are reason why it's done this way, feel free to close this PR, of course.