### PR TITLE
LspInstall not working in linux

### DIFF
--- a/lua/nvim_lsp/util.lua
+++ b/lua/nvim_lsp/util.lua
@@ -392,7 +392,7 @@ function M.npm_installer(config)
     set -e
     mkdir -p "{{install_dir}}"
     cd "{{install_dir}}"
-    npm init -y
+    [ ! -f package.json ] && npm init -y
     npm install {{packages}} --no-package-lock --no-save --production
     {{post_install_script}}
     ]]):gsub("{{(%S+)}}", install_params)

--- a/lua/nvim_lsp/util.lua
+++ b/lua/nvim_lsp/util.lua
@@ -392,6 +392,7 @@ function M.npm_installer(config)
     set -e
     mkdir -p "{{install_dir}}"
     cd "{{install_dir}}"
+    npm init -y
     npm install {{packages}} --no-package-lock --no-save --production
     {{post_install_script}}
     ]]):gsub("{{(%S+)}}", install_params)


### PR DESCRIPTION
not sure about other platform, but in my linux, when I ran 
```
LspInstall bashls
```
it failed to install.
it turned out the repo was not initialized.
so I added one line of code to check if package.json exists or not, if not, then init it.