### PR TITLE
Correct "fluttreOutline" typo for `dartls`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1443,7 +1443,7 @@ require'nvim_lsp'.dartls.setup{}
     filetypes = { "dart" }
     init_options = {
       closingLabels = "true",
-      fluttreOutline = "false",
+      flutterOutline = "false",
       onlyAnalyzeProjectsWithOpenFiles = "false",
       outline = "true",
       suggestFromUnimportedLibraries = "true"


### PR DESCRIPTION
The [Dart LSP spec](https://github.com/dart-lang/sdk/tree/master/pkg/analysis_server/tool/lsp_spec) shows that this option is `flutterOutline`, and I believe this was the intent of the original author of this file.