### PR TITLE
pyls_ms - Remove call to get Python interpreter and version.

### DIFF
--- a/lua/nvim_lsp/pyls_ms.lua
+++ b/lua/nvim_lsp/pyls_ms.lua
@@ -3,13 +3,6 @@ local util = require 'nvim_lsp/util'
 
 local name = "pyls_ms"
 
-local function get_python_version()
-  local f = io.popen("python --version 2>&1") -- runs command
-  local l = f:read("*a") -- read output of command
-  f:close()
-  return l:match("^Python%s*(...).*%s*$")
-end
-
 local function get_latest_pyls()
   local f = io.popen("curl -k --silent 'https://pvsc.blob.core.windows.net/python-language-server-stable?restype=container&comp=list&prefix=Python-Language-Server-osx-x64'")
   local l = f:read("*a")
@@ -110,8 +103,8 @@ configs[name] = {
       interpreter = {
         properties =
         {
-          InterpreterPath = vim.fn.exepath("python");
-          Version = get_python_version();
+          InterpreterPath = "";
+          Version = "";
         };
       };
       displayOptions = {};
@@ -137,6 +130,13 @@ If you want to use your own build, set cmd to point to `Microsoft.Python.languag
 
 ```lua
 cmd = { "dotnet", "exec", "path/to/Microsoft.Python.languageServer.dll" };
+```
+
+If the `python` interpreter is not in your PATH environment variable, set the `InterpreterPath` and `Version` properties accordingly.
+
+```lua
+InterpreterPath = "path/to/python",
+Version = "3.8"
 ```
 
 This server accepts configuration via the `settings` key.


### PR DESCRIPTION
By default, the Microsoft Python Language Server already gets an existing Python interpreter and version from $PATH if the setting is an empty string or null.

[src/LanguageServer/Impl/Implementation/Server.cs](https://github.com/microsoft/python-language-server/blob/838ba78e00173d639bd90f54d8610ec16b4ba3a2/src/LanguageServer/Impl/Implementation/Server.cs#L143-L157)
```c#
var interpeterPath = initializationOptions?.interpreter.properties?.InterpreterPath;
Version version = null;


if (!string.IsNullOrWhiteSpace(interpeterPath)) {
	Version.TryParse(initializationOptions?.interpreter.properties?.Version, out version);
} else {
	var fs = _services.GetService<IFileSystem>();
	var exePath = PathUtils.LookPath(fs, "python");
	if (exePath != null && TryGetPythonVersion(exePath, out version)) {
		_log?.Log(TraceEventType.Information, Resources.UsingPythonFromPATH);
		interpeterPath = exePath;
	} else {
		interpeterPath = null;
	}
}

```
Thus, looking for `python` and launching the interpreter to get the version on our end is redundant and time-consuming.