### PR TITLE
Add details to generate a compile_commands.json file for ccls and clangd

### DIFF
--- a/lua/nvim_lsp/ccls.lua
+++ b/lua/nvim_lsp/ccls.lua
@@ -14,6 +14,7 @@ https://github.com/MaskRay/ccls/wiki
 
 ccls relies on a [JSON compilation database](https://clang.llvm.org/docs/JSONCompilationDatabase.html) specified
 as compile_commands.json or, for simpler projects, a compile_flags.txt.
+For details on how to automatically generate one using CMake look [here](https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html).
 ]];
     default_config = {
       root_dir = [[root_pattern("compile_commands.json", "compile_flags.txt", ".git")]];

--- a/lua/nvim_lsp/clangd.lua
+++ b/lua/nvim_lsp/clangd.lua
@@ -46,6 +46,7 @@ https://clang.llvm.org/extra/clangd/Installation.html
 
 clangd relies on a [JSON compilation database](https://clang.llvm.org/docs/JSONCompilationDatabase.html) specified
 as compile_commands.json or, for simpler projects, a compile_flags.txt.
+For details on how to automatically generate one using CMake look [here](https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html).
 ]];
     default_config = {
       root_dir = [[root_pattern("compile_commands.json", "compile_flags.txt", ".git") or dirname]];


### PR DESCRIPTION
This PR adds two identical lines in the README.md for ccls and clangd, giving details on how to easily generate a `compile_commands.txt` file using CMake.

Generating a `compile_commands.txt` file might look a cumbersome task, but CMake actually has an integration to automatically generate one inside the `${CMAKE_BINARY_DIR}` directory.
Having a reference to the CMake documentation when describing the need for a `compile_commands.txt` file might be helpful for someone.