### PR TITLE
[RFC] don't start up LSP for 'nofile' buffers

### DIFF
--- a/lua/nvim_lsp/configs.lua
+++ b/lua/nvim_lsp/configs.lua
@@ -171,6 +171,9 @@ function configs.__newindex(t, config_name, config_def)
     end)
 
     function manager.try_add()
+      if vim.bo.buftype == 'nofile' then
+        return
+      end
       local root_dir = get_root_dir(api.nvim_buf_get_name(0), api.nvim_get_current_buf())
       local id = manager.add(root_dir)
       if id then


### PR DESCRIPTION
high level goal is to allow users some way to set filetype for a buffer in cases where they don't want to start up an LSP server, e.g. in a fuzzy finder preview

cc @tjdevries 