### PR TITLE
Use .merlin as identifier for ocamllsp, not merlin

### DIFF
--- a/lua/nvim_lsp/ocamllsp.lua
+++ b/lua/nvim_lsp/ocamllsp.lua
@@ -5,7 +5,7 @@ configs.ocamllsp = {
   default_config = {
     cmd = {"ocamllsp",};
     filetypes = {'ocaml', 'reason'};
-    root_dir = util.root_pattern("merlin", "package.json", ".git");
+    root_dir = util.root_pattern(".merlin", "package.json", ".git");
   };
   docs = {
     description = [[


### PR DESCRIPTION
This was missing the dot before. See https://github.com/ocaml/merlin/wiki/project-configuration for details on the file.